### PR TITLE
Change pantherdb request to https instead of http

### DIFF
--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -2219,8 +2219,12 @@ def get_legal_panther_taxons():
     URL = 'https://www.pantherdb.org/services/oai/pantherdb/supportedgenomes'
     req = requests.post(URL)
     req.raise_for_status()
-    entries = json.loads(req.text)['search']['output']['genomes']['genome']
-    taxons = tuple(sorted(d['long_name'] for d in entries))
+    genomes = req.json()['search']['output']['genomes']['genome']
+    # PantherDB returns a single genome dict (not a list) when only one genome is present; normalize
+    # to a list the way the ortholog endpoints already do, and skip any entry lacking a long_name.
+    entries = parsing.data_to_list(genomes)
+    taxons = tuple(sorted(entry['long_name'] for entry in entries
+                          if isinstance(entry, dict) and 'long_name' in entry))
     return taxons
 
 

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -1758,7 +1758,7 @@ class EnsemblOrthologMapper:
 
 
 class PantherOrthologMapper:
-    API_URL = 'http://www.pantherdb.org'
+    API_URL = 'https://www.pantherdb.org'
     RETRIES = RandomExpRetry(total=5, backoff_factor=0.25, status_forcelist=[500, 502, 503, 504])
     HEADERS = {'accept': 'application/json'}
 
@@ -2216,7 +2216,7 @@ def find_best_gene_mapping(ids: Tuple[str, ...], map_from_options: Union[Tuple[s
 
 @functools.lru_cache(maxsize=2)
 def get_legal_panther_taxons():
-    URL = 'http://www.pantherdb.org/services/oai/pantherdb/supportedgenomes'
+    URL = 'https://www.pantherdb.org/services/oai/pantherdb/supportedgenomes'
     req = requests.post(URL)
     req.raise_for_status()
     entries = json.loads(req.text)['search']['output']['genomes']['genome']

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -96,7 +96,10 @@ def get_gene_id_types() -> typing.Tuple[str, ...]:
 def get_panther_taxons() -> typing.Tuple[str, ...]:
     try:
         taxons = io.get_legal_panther_taxons()
-    except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
+    except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError,
+            KeyError, ValueError, TypeError):
+        # Also swallow parse errors: once PantherDB answers 200 (over https) but in an unexpected
+        # shape, json/key/type errors would otherwise crash instead of degrading gracefully.
         taxons = tuple()
         warnings.warn('Failed to retrieve legal taxons from PantherDB. '
                       'Some features may not work as intended. '

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1853,3 +1853,30 @@ class TestRunRScript:
         monkeypatch.setattr(subprocess, 'Popen', mock_popen)
         with pytest.raises(FileNotFoundError):
             run_r_script('tests/test_files/test_r_script.R')
+
+
+@pytest.mark.parametrize('genome_node,expected', [
+    # PantherDB normally returns a list of genome dicts...
+    ([{'long_name': 'Homo sapiens'}, {'long_name': 'Caenorhabditis elegans'}],
+     ('Caenorhabditis elegans', 'Homo sapiens')),
+    # ...but returns a single dict (not a list) when only one genome is present.
+    ({'long_name': 'Homo sapiens'}, ('Homo sapiens',)),
+    # entries without a long_name are skipped rather than raising.
+    ([{'long_name': 'Homo sapiens'}, {'name': 'no_long_name'}], ('Homo sapiens',)),
+])
+def test_get_legal_panther_taxons_handles_list_and_single(monkeypatch, genome_node, expected):
+    payload = {'search': {'output': {'genomes': {'genome': genome_node}}}}
+
+    class _FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(io.requests, 'post', lambda *a, **kw: _FakeResp())
+    io.get_legal_panther_taxons.cache_clear()
+    try:
+        assert io.get_legal_panther_taxons() == expected
+    finally:
+        io.get_legal_panther_taxons.cache_clear()


### PR DESCRIPTION
http://www.pantherdb.org is not available anymore
@GuyTeichman when I reinstalled the app running `from rnalysis import gui` failed and returned
```
Warning: Failed to retreive legal taxons from PantherDB. Some features may not work as intended. To fix this issue, make sure your computer has internet connection, and restart RNAlysis.
```
When I fixed the address it seems to work fine.