### PR TITLE
Fix user-facing typos and XL-mHG citation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ If you use the *XL-mHG* single-set enrichment test in your research, please cite
 
     Eden, E., Lipson, D., Yogev, S., and Yakhini, Z. (2007).
      Discovering Motifs in Ranked Lists of DNA Sequences. PLOS Comput. Biol. 3, e39.
-    https://doi.org/10.1371/journal.pcbi.0030039>doi.org/10.1371/journal.pcbi.0030039</a>
+    https://doi.org/10.1371/journal.pcbi.0030039
 
     Wagner, F. (2017). The XL-mHG test for gene set enrichment. ArXiv.
     https://doi.org/10.48550/arXiv.1507.07905

--- a/rnalysis/utils/generic.py
+++ b/rnalysis/utils/generic.py
@@ -286,7 +286,7 @@ def sanitize_variable_name(name: str) -> str:
     Sanitize a string to turn it into a legal variable name in R/Python.
     :param name: name to sanitize
     :type name: str
-    :return: sanitizeed name
+    :return: sanitized name
     :rtype: str
     """
     new_name = name.rstrip().replace(' ', '_')

--- a/rnalysis/utils/installs.py
+++ b/rnalysis/utils/installs.py
@@ -105,7 +105,7 @@ def install_limma(r_installation_folder: Union[str, Path, Literal['auto']] = 'au
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install limma. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install limma manually.")
 
 
@@ -115,7 +115,7 @@ def install_deseq2(r_installation_folder: Union[str, Path, Literal['auto']] = 'a
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install DESeq2. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install DESeq2 manually.")
 
 
@@ -125,5 +125,5 @@ def install_rsubread(r_installation_folder: Union[str, Path, Literal['auto']] = 
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install RSubread. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install RSubread manually.")

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -85,7 +85,7 @@ def get_gene_id_types() -> typing.Tuple[str, ...]:
         gene_id_types = parsing.data_to_tuple(io.get_legal_gene_id_types()[0].keys())
     except requests.exceptions.ConnectionError:
         gene_id_types = tuple()
-        warnings.warn('Failed to retreive gene ID mapping data from UniProtKB. '
+        warnings.warn('Failed to retrieve gene ID mapping data from UniProtKB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -98,7 +98,7 @@ def get_panther_taxons() -> typing.Tuple[str, ...]:
         taxons = io.get_legal_panther_taxons()
     except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from PantherDB. '
+        warnings.warn('Failed to retrieve legal taxons from PantherDB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -111,7 +111,7 @@ def get_phylomedb_taxons() -> typing.Tuple[str, ...]:
         taxons = io.get_legal_phylomedb_taxons()
     except ftplib.all_errors:
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from PhylomeDB. '
+        warnings.warn('Failed to retrieve legal taxons from PhylomeDB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -124,7 +124,7 @@ def get_ensembl_taxons() -> typing.Tuple[str, ...]:
         taxons = parsing.data_to_tuple(io.get_legal_ensembl_taxons())
     except (requests.exceptions.ConnectionError, tenacity.RetryError):
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from Ensembl. '
+        warnings.warn('Failed to retrieve legal taxons from Ensembl. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -268,7 +268,7 @@ def flatten(lst: list) -> list:
 
 def parse_docstring(docstring: str) -> Tuple[str, Dict[str, str]]:
     """
-    Parse a given docstring (str) to retreive the description text, as well as a dictionary of parameter descriptions.
+    Parse a given docstring (str) to retrieve the description text, as well as a dictionary of parameter descriptions.
 
     :param docstring: the docstring to be parsed
     :type docstring: str


### PR DESCRIPTION
## Summary
- correct misspelled retrieval warnings and R installation permission errors
- fix two utility docstring typos
- repair the malformed XL-mHG DOI in the README

## Validation
- `python3 -m compileall -q rnalysis/utils/param_typing.py rnalysis/utils/installs.py rnalysis/utils/generic.py rnalysis/utils/parsing.py`
- `git diff --check`

The focused pytest suite was not run because pytest is unavailable in the local Python environment.

Fixes #60