### PR TITLE
Fix user-facing typos and modernize CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,7 +77,7 @@ of things that could be improved in the source code, and of possible algorithmic
 *RNAlysis* Design Philosophy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a guiding priniple for future development of *RNAlysis*, see this short list of the general design principle *RNAlysis* should follow:
+As a guiding principle for future development of *RNAlysis*, see this short list of the general design principles *RNAlysis* should follow:
 
 * **Universality** - *RNAlysis* should be usable on most computers. This means new features should be supported by commonly-used operating systems (Windows, Linux, MacOS) and currently supported Python versions. In the best case scenario, users who open *RNAlysis* should never ask themselves "which of these functions/modules are supported by my operating system?"
 * **Graphical and Programmatic support** - The majority of *RNAlysis* features should be usable both in the Graphical User Interface, and in Python scripts.
@@ -93,26 +93,30 @@ Ready to contribute? Here's how to set up `rnalysis` for local development.
 
     $ git clone git@github.com:your_name_here/rnalysis.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+3. Install your local copy into a virtual environment::
 
-    $ mkvirtualenv rnalysis
     $ cd rnalysis/
-    $ python setup.py develop
+    $ python -m venv venv
+    $ source venv/bin/activate    # on Windows: venv\Scripts\activate
+    $ pip install -e .[all]
+    $ pip install -r requirements_dev.txt
 
-4. Create a branch for local development::
+4. Create a branch for local development, based on the ``development`` branch
+   (``development`` is the integration branch; ``master`` only receives ``development``
+   at a version release)::
 
+    $ git checkout development
     $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+5. When you're done making changes, check that the tests still pass::
 
-    $ flake8 rnalysis tests
-    $ python setup.py test or py.test
-    $ tox
+    $ pytest tests/
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   While iterating you can run a single module, e.g. ``pytest tests/test_filtering.py``.
+   Note that the full suite is long and some tests require R, kallisto, bowtie2, or network
+   access. New code should come with tests.
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -120,7 +124,7 @@ Ready to contribute? Here's how to set up `rnalysis` for local development.
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+7. Submit a pull request through the GitHub website, targeting the ``development`` branch.
 
 Pull Request Guidelines
 -----------------------
@@ -131,27 +135,31 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python versions 3.7 - 3.10, and for PyPy. Check
-   https://coveralls.io/github/GuyTeichman/RNAlysis
-   and make sure that the tests pass for all supported Python versions.
+3. Open the pull request against the ``development`` branch.
+4. The pull request should work across the supported Python versions (currently 3.10 - 3.14)
+   on Windows, macOS, and Linux. GitHub Actions runs this matrix automatically on every pull
+   request; make sure all jobs pass. Coverage is reported at
+   https://coveralls.io/github/GuyTeichman/RNAlysis.
 
 Tips
 ----
 
 To run a subset of tests::
 
-$ py.test tests.test_rnalysis
+$ pytest tests/test_filtering.py
 
 
 Deploying
 ---------
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed (including an entry in HISTORY.rst).
-Then run::
+Make sure all your changes are committed (including an entry in HISTORY.rst), and that
+``development`` has been merged into ``master``.
+Then, from ``master``, run::
 
 $ bumpversion patch # possible: major / minor / patch
 $ git push
 $ git push --tags
 
-Travis will then deploy to PyPI if tests pass.
+GitHub Actions will then build and publish the release (PyPI package and standalone installers)
+when the tests pass.

--- a/README.rst
+++ b/README.rst
@@ -188,8 +188,8 @@ If you use the *HDBSCAN* clustering feature in your research, please cite::
 If you use the *XL-mHG* single-set enrichment test in your research, please cite::
 
     Eden, E., Lipson, D., Yogev, S., and Yakhini, Z. (2007).
-     Discovering Motifs in Ranked Lists of DNA Sequences. PLOS Comput. Biol. 3, e39.
-    https://doi.org/10.1371/journal.pcbi.0030039>doi.org/10.1371/journal.pcbi.0030039</a>
+    Discovering Motifs in Ranked Lists of DNA Sequences. PLOS Comput. Biol. 3, e39.
+    https://doi.org/10.1371/journal.pcbi.0030039
 
     Wagner, F. (2017). The XL-mHG test for gene set enrichment. ArXiv.
     https://doi.org/10.48550/arXiv.1507.07905

--- a/rnalysis/general.py
+++ b/rnalysis/general.py
@@ -126,7 +126,7 @@ def set_biotype_ref_table_path(path: str = None):
     Biotype Reference Table path set as: my_biotype_reference_table_path
     """
     if path is None:
-        path = input("Please write the new Attribute Reference Table Path:\n")
+        path = input("Please write the new Biotype Reference Table Path:\n")
     settings.update_settings_file(path, __biotype_file_key__)
     print(f'Biotype Reference Table path set as: {path}')
 

--- a/rnalysis/utils/generic.py
+++ b/rnalysis/utils/generic.py
@@ -286,7 +286,7 @@ def sanitize_variable_name(name: str) -> str:
     Sanitize a string to turn it into a legal variable name in R/Python.
     :param name: name to sanitize
     :type name: str
-    :return: sanitizeed name
+    :return: sanitized name
     :rtype: str
     """
     new_name = name.rstrip().replace(' ', '_')

--- a/rnalysis/utils/installs.py
+++ b/rnalysis/utils/installs.py
@@ -105,7 +105,7 @@ def install_limma(r_installation_folder: Union[str, Path, Literal['auto']] = 'au
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install limma. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install limma manually.")
 
 
@@ -115,7 +115,7 @@ def install_deseq2(r_installation_folder: Union[str, Path, Literal['auto']] = 'a
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install DESeq2. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install DESeq2 manually.")
 
 
@@ -125,5 +125,5 @@ def install_rsubread(r_installation_folder: Union[str, Path, Literal['auto']] = 
         io.run_r_script(script_path, r_installation_folder)
     except AssertionError:
         raise AssertionError("Failed to install RSubread. "
-                             "Please make sure you have write premission to R's library folder, "
+                             "Please make sure you have write permission to R's library folder, "
                              "or try to install RSubread manually.")

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -39,7 +39,7 @@ DEFAULT_ORGANISMS = tuple(sorted(['Caenorhabditis elegans',
                                   'Mus musculus',
                                   'Drosophila melanogaster',
                                   'Homo sapiens',
-                                  'Arabodopsis thaliana',
+                                  'Arabidopsis thaliana',
                                   'Danio rerio',
                                   'Escherichia coli',
                                   'Saccharomyces cerevisiae',
@@ -85,7 +85,7 @@ def get_gene_id_types() -> typing.Tuple[str, ...]:
         gene_id_types = parsing.data_to_tuple(io.get_legal_gene_id_types()[0].keys())
     except requests.exceptions.ConnectionError:
         gene_id_types = tuple()
-        warnings.warn('Failed to retreive gene ID mapping data from UniProtKB. '
+        warnings.warn('Failed to retrieve gene ID mapping data from UniProtKB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -98,7 +98,7 @@ def get_panther_taxons() -> typing.Tuple[str, ...]:
         taxons = io.get_legal_panther_taxons()
     except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from PantherDB. '
+        warnings.warn('Failed to retrieve legal taxons from PantherDB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -111,7 +111,7 @@ def get_phylomedb_taxons() -> typing.Tuple[str, ...]:
         taxons = io.get_legal_phylomedb_taxons()
     except ftplib.all_errors:
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from PhylomeDB. '
+        warnings.warn('Failed to retrieve legal taxons from PhylomeDB. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')
@@ -124,7 +124,7 @@ def get_ensembl_taxons() -> typing.Tuple[str, ...]:
         taxons = parsing.data_to_tuple(io.get_legal_ensembl_taxons())
     except (requests.exceptions.ConnectionError, tenacity.RetryError):
         taxons = tuple()
-        warnings.warn('Failed to retreive legal taxons from Ensembl. '
+        warnings.warn('Failed to retrieve legal taxons from Ensembl. '
                       'Some features may not work as intended. '
                       'To fix this issue, make sure your computer has internet connection, '
                       'and restart RNAlysis. ')

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -268,7 +268,7 @@ def flatten(lst: list) -> list:
 
 def parse_docstring(docstring: str) -> Tuple[str, Dict[str, str]]:
     """
-    Parse a given docstring (str) to retreive the description text, as well as a dictionary of parameter descriptions.
+    Parse a given docstring (str) to retrieve the description text, as well as a dictionary of parameter descriptions.
 
     :param docstring: the docstring to be parsed
     :type docstring: str

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -69,6 +69,22 @@ def test_set_biotype_ref_path():
     assert success_2
 
 
+def test_set_biotype_ref_table_path_prompt_refers_to_biotype(monkeypatch):
+    # Regression guard: when no path is given, the prompt must refer to the *Biotype* reference
+    # table, not the *Attribute* one (they are separate settings).
+    settings.make_temp_copy_of_settings_file()
+    prompts = []
+    monkeypatch.setattr('builtins.input', lambda prompt='': (prompts.append(prompt), 'temp/path')[1])
+
+    set_biotype_ref_table_path()  # path=None -> triggers the input() prompt
+
+    settings.set_temp_copy_of_settings_file_as_default()
+    settings.remove_temp_copy_of_settings_file()
+    assert len(prompts) == 1
+    assert 'Biotype' in prompts[0]
+    assert 'Attribute' not in prompts[0]
+
+
 def test_reset_settings_file():
     settings.make_temp_copy_of_settings_file()
     try:

--- a/tests/test_param_typing.py
+++ b/tests/test_param_typing.py
@@ -1,0 +1,8 @@
+from rnalysis.utils.param_typing import DEFAULT_ORGANISMS
+
+
+def test_default_organisms_are_spelled_correctly():
+    # These names are used as live taxonomy-search queries (io.map_taxon_id); a misspelling degrades
+    # the match. Guard the historically-misspelled entry in particular.
+    assert 'Arabidopsis thaliana' in DEFAULT_ORGANISMS
+    assert 'Arabodopsis thaliana' not in DEFAULT_ORGANISMS


### PR DESCRIPTION
## Fix user-facing typos and modernize `CONTRIBUTING.rst`

Cleanup surfaced during codebase exploration. Closes #58, #59, #60, #56.

### Typos (user-facing strings / docstrings — several also feed GUI help text)
- **`general.set_biotype_ref_table_path`** — the interactive prompt said *"Attribute Reference Table Path"* instead of *"Biotype Reference Table Path"*. These are two different settings, so the prompt actively misled users. *(#58)*
- **`param_typing.DEFAULT_ORGANISMS`** — `"Arabodopsis thaliana"` → `"Arabidopsis thaliana"`. This string is sent as a live **taxonomy-search query** (`io.map_taxon_id`), so the misspelling degraded the match; the correct name resolves cleanly. Saved sessions storing the old string are unaffected (this only changes the default dropdown list). *(#59)*
- `"retreive"` → `"retrieve"` — 4 warning messages in `param_typing.py` + a `parsing.py` docstring. *(#60)*
- `"premission"` → `"permission"` — the three R-install error messages in `installs.py`. *(#60)*
- `"sanitizeed"` → `"sanitized"` — `generic.sanitize_variable_name` docstring. *(#60)*
- **`README.rst`** — repaired the mangled XL-mHG citation link (stray `>...</a>` HTML and a duplicated URL). *(#60)*

### Staleness — `CONTRIBUTING.rst` *(#56)*
Replaced outdated instructions with current reality:
- `mkvirtualenv` / `python setup.py develop` → `python -m venv` + `pip install -e .[all]` + `requirements_dev.txt`.
- `flake8` / `tox` / `python setup.py test` / `py.test tests.test_rnalysis` → `pytest tests/` (with a real example module).
- "Python 3.7 - 3.10, and PyPy" → the actual supported range **3.10 - 3.14** across Windows/macOS/Linux, tested by GitHub Actions.
- "Travis will then deploy" → GitHub Actions builds/publishes the release.
- Documented the **`development` → `master`** branch model (branch off `development`, PR into `development`).
- Fixed a "priniple" typo in the Design Philosophy section.

### Tests
Two fast regression guards (TDD — both were red before the fix):
- `test_set_biotype_ref_table_path_prompt_refers_to_biotype`
- `test_default_organisms_are_spelled_correctly` (new `tests/test_param_typing.py`)

Verified locally (Windows, Python 3.12): `tests/test_general.py` + `tests/test_param_typing.py` pass (10 tests); all edited modules import cleanly; no `retreive`/`premission`/`sanitizeed`/`Arabodopsis` occurrences remain in `rnalysis/`.

**No behavior/results change** beyond the corrected prompt label and the (improved) organism-name query; no serialized-format impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
