### PR TITLE
Speed up slow clustering/pipeline unit tests

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1628,11 +1628,18 @@ def test_pipeline_apply_to_multiple_splits(basic_countfilter):
 
 
 def test_pipeline_apply_to_filter_normalize_split_plot(big_countfilter):
+    # Note: n=17500 (instead of a smaller value) is deliberately chosen so that filter_top_n
+    # leaves only ~2500 of the ~20000 rows before the clustering/plotting steps. This is a
+    # self-consistency check (Pipeline.apply_to vs. the same calls made manually) with no
+    # comparison to a committed truth file, so shrinking the data flowing through the slow
+    # clustering steps (split_hdbscan, clustergram, split_kmedoids) is safe as long as it still
+    # produces multiple non-trivial clusters, which it does (verified to leave >=2 clusters of
+    # size >= 7, so split_kmedoids(n_clusters=[2, 7]) remains valid on each).
     scaling_factor_path = 'tests/test_files/big_scaling_factors.csv'
     pl_c = Pipeline('CountFilter')
     pl_c.add_function(CountFilter.normalize_with_scaling_factors, scaling_factor_path)
     pl_c.add_function('biotypes_from_ref_table', ref=__biotype_ref__)
-    pl_c.add_function(CountFilter.filter_top_n, by='cond3rep1', n=1500, opposite=True)
+    pl_c.add_function(CountFilter.filter_top_n, by='cond3rep1', n=17500, opposite=True)
     pl_c.add_function(CountFilter.split_hdbscan, min_cluster_size=40, return_probabilities=True)
     pl_c.add_function(CountFilter.filter_low_reads, threshold=10)
     pl_c.add_function(CountFilter.clustergram)
@@ -1645,7 +1652,7 @@ def test_pipeline_apply_to_filter_normalize_split_plot(big_countfilter):
     c_dict = dict()
     c.normalize_with_scaling_factors(scaling_factor_path)
     c_dict['biotypes_from_ref_table_1'] = c.biotypes_from_ref_table(ref=__biotype_ref__)
-    c_res = c.filter_top_n(by='cond3rep1', n=1500, opposite=True, inplace=False)
+    c_res = c.filter_top_n(by='cond3rep1', n=17500, opposite=True, inplace=False)
     c_res, prob = c_res.split_hdbscan(min_cluster_size=40, return_probabilities=True)
     c_dict['split_hdbscan_1'] = prob
     for obj in c_res:
@@ -1683,7 +1690,12 @@ def test_pipeline_apply_to_filter_normalize_split_plot(big_countfilter):
 
 
 def test_gap_statistic_api(clustering_countfilter):
-    res = clustering_countfilter.split_kmeans(n_clusters='gap')
+    # The gap statistic evaluates every candidate k from 2 up to max_n_clusters_estimate (default
+    # 'auto' -> 20 here), fitting KMeans on 10 reference datasets per k. The assertion below only
+    # checks the return type, not a specific k or a truth file, so capping max_n_clusters_estimate
+    # at 5 (still >1, so the multi-k search code path is still exercised) cuts the number of KMeans
+    # fits substantially while testing the same behavior.
+    res = clustering_countfilter.split_kmeans(n_clusters='gap', max_n_clusters_estimate=5)
     assert isinstance(res, tuple)
 
 
@@ -1740,7 +1752,14 @@ def test_split_hdbscan_api(clustering_countfilter):
 
 
 def test_split_clicom_api(clustering_countfilter):
-    c = clustering_countfilter
+    # split_clicom's cluster-similarity-matrix step scales roughly with the square of the number
+    # of features, and this test only checks structural correctness of the split (no comparison to
+    # a committed truth file), so we shrink the working data to the first 300 (of 1345) features to
+    # keep the same code path (all 3 clustering methods, multi-value parameter combos, and the
+    # power_transform=(False, True) branch) while running much faster. 300 rows is still comfortably
+    # more than the largest n_clusters/min_cluster_size used below.
+    c = CountFilter.from_dataframe(clustering_countfilter.df.head(300), clustering_countfilter.fname,
+                                   clustering_countfilter.is_normalized, suppress_warnings=True)
     res = c.split_clicom({'method': 'hdbscan', 'min_cluster_size': [75, 40], 'metric': ['ys1', 'spearman']},
                          {'method': 'hierarchical', 'n_clusters': [7], 'metric': ['euclidean', 'jackknife'],
                           'linkage': ['average', 'ward']},
@@ -2371,7 +2390,14 @@ def test_map_orthologs_orthoinspector(mock_mapper, non_unique_mode, remove_unmap
     (3, True, True)
 ])
 def test_sort_by_principal_component(clustering_countfilter, component, ascending, power_transform):
-    c = clustering_countfilter
+    # sort_by_principal_component(power_transform=True) runs a separate Box-Cox optimization per gene
+    # (the data is transposed before the power transform), so its cost scales ~linearly with the
+    # number of genes. This test only checks structural/self-consistency properties (isinstance,
+    # inequality/equality between calls, and raised AssertionErrors) rather than a committed truth
+    # file, so shrinking the working data to the first 300 (of 1345) genes keeps the same code path
+    # while cutting the power_transform=True cases from ~25-30s each to a few seconds.
+    c = CountFilter.from_dataframe(clustering_countfilter.df.head(300), clustering_countfilter.fname,
+                                   clustering_countfilter.is_normalized, suppress_warnings=True)
     c_sorted = c.sort_by_principal_component(component, ascending=ascending, power_transform=power_transform,
                                              inplace=False)
     assert isinstance(c_sorted, CountFilter)


### PR DESCRIPTION
## Summary

Shrinks the runtime of the slowest tests in the `unit` marker tier without weakening any assertion, deleting any assertion, or touching any committed truth file. All of the touched tests only assert structural/self-consistency properties (isinstance checks, `Pipeline.apply_to` vs. manual-call equivalence, raised errors) — none of them compare against a committed truth file — so the size of data flowing through their slow clustering/plotting steps, and the number of clustering setups / candidate-k values they evaluate, could be safely reduced.

| Test | Before (call) | After (call) | Change |
|---|---|---|---|
| `test_pipeline_apply_to_filter_normalize_split_plot` | 79.9s | ~5.2s | raised the `filter_top_n` cutoff so far fewer rows reach `split_hdbscan`/`clustergram`/`split_kmedoids` |
| `test_split_clicom_api` | 31.4s (task) / 24.3s (measured) | ~3-6s | shrank the working `CountFilter` to its first 300 (of 1345) features — `split_clicom`'s similarity-matrix step is ~O(n^2) |
| `test_sort_by_principal_component[1-True-True]` | 30.1s | ~3.5-6s | same 300-feature shrink — the Box-Cox power transform is fit once per gene |
| `test_sort_by_principal_component[3-True-True]` | 20.5s | ~3.5-6s | same 300-feature shrink |
| `test_gap_statistic_api` | 13.2s | ~2-6s | capped `max_n_clusters_estimate` at 5 instead of the default 20, cutting the number of KMeans fits |

Measured total for these 5 test cases dropped from ~175s to ~18-25s (roughly 7-10x), depending on machine warm-up state.

`test_compute_dispersion` and `test_clicom_cluster_wise_result` were profiled but **left unchanged**: their ~4-5s runtime is a one-time process warm-up cost (sklearn's first `KMeans.fit` call, and joblib's `LokyBackend` worker-pool startup, respectively) that is completely independent of any parameter these tests control — confirmed by re-running the same calls twice in the same process (first call ~4-5s, every subsequent call ~0.01s). No safe lever exists to reduce this without fabricating an unrelated warm-up call, so per the "leave unchanged and report why" rule they were left as-is.

`tests/test_enrichment_runner.py::test_calc_randomization_pval` was **not touched**: that file currently fails to collect under pytest 9 on `development` (trailing commas inside `parametrize` argname strings), a pre-existing, unrelated issue owned by a separate PR (#74).

## Test plan
- [x] Ran each modified test individually multiple times to confirm it still passes and to check timing stability
- [x] Ran the full `tests/test_filtering.py` module (364 passed) to confirm no collateral breakage
- [x] Ran the full `tests/test_clustering.py` module (43 passed) as a control (unmodified, confirms the warm-up-cost analysis for the two left-unchanged tests)
- [ ] Could not run the full suite (R / kallisto / bowtie2 / network-dependent tests are not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
