### PR TITLE
CI: bump actions off deprecated Node.js 20 (checkout v5, setup-python v6, cache v5)

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -40,7 +40,7 @@ jobs:
                 run: |
                     (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize
             -   name: Get repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     # docs/build/ is ~600 MB of committed, generated Sphinx output that the tests
                     # never read. Excluding it from the sparse checkout speeds up "Get repository".
@@ -61,7 +61,7 @@ jobs:
             -   name: Cache LLVM and Clang
                 if: runner.os != 'macOS'
                 id: cache-llvm
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: ${{ runner.temp }}/llvm
                     key: llvm
@@ -79,7 +79,7 @@ jobs:
             -   name: Cache R packages (DESeq2/limma/Rsubread)
                 # The DE/featureCounts integration tests compile these Bioconductor packages from
                 # source at test time; caching R_LIBS_USER avoids recompiling them on every run.
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: ${{ github.workspace }}/.r-libs
                     key: r-libs-${{ runner.os }}-R4.4-${{ hashFiles('rnalysis/data_files/r_templates/*_install.R') }}
@@ -105,7 +105,7 @@ jobs:
                 run: Rscript -e "print('R script ran successfully')"
             -   name: Cache kallisto & bowtie2 binaries
                 id: cache-bio-tools
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: |
                         ${{ github.workspace }}/kallisto
@@ -158,7 +158,7 @@ jobs:
                     bowtie2 --version
                     bowtie2-build-s --version
             -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v4
+                uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
                     cache: 'pip'


### PR DESCRIPTION
Top of the stack. Clears the *"Node.js 20 is deprecated ... forced to run on Node.js 24"* warning by bumping each affected action to the lowest major that ships a Node 24 runtime (verified against each `action.yml`):

| action | was | now | note |
|---|---|---|---|
| actions/checkout | v4 | **v5** | `sparse-checkout` (used by this stack) is supported since v4.1 |
| actions/setup-python | v4 | **v6** | v5 is still Node 20; v6 is the first Node 24 major |
| actions/cache | v4 | **v5** | all three cache steps (LLVM, R packages, kallisto/bowtie2) |
| tlambert03/setup-qt-libs | v1 | v1 | **no Node 24 release exists** (latest tag still `node20`) — nothing to bump to |
| ts-graphviz/setup-graphviz | v2 | v2 | same — no Node 24 release yet |

### Stack (bottom → top)
`development` ← #74 ← #81 ← #80 ← #78 ← **this**. As the top, this branch physically contains all four PRs, so its CI is the single green signal for the whole chain. Merge the chain bottom-up (or squash-merge from the bottom as each turns green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)