### PR TITLE
Retry transient UniProt idmapping-status 400s

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Fixed
 ******
 * Fixed a bug in ``CountFilter.pairplot`` where the Spearman correlation shown for the first row/column of the plot was computed against the gene-index column instead of a sample, producing an incorrect value (and, with recent NumPy versions, an error). The correlations are now always computed between the correct pair of samples.
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
+* Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -1877,6 +1877,13 @@ class GeneIDTranslator:
     REQUEST_DELAY_MILLIS = 250
     REQ_MAX_ENTRIES = 10
     RETRIES = RandomExpRetry(total=5, backoff_factor=0.25, status_forcelist=[500, 502, 503, 504])
+    # UniProt's idmapping *status* endpoint intermittently answers a valid jobId with a transient
+    # HTTP 400 (seen when the status is polled before the job is fully registered, or under heavy
+    # concurrent load such as many parallel CI jobs). 400 is deliberately absent from RETRIES'
+    # status_forcelist because a 400 usually means a genuinely bad request, so we retry it only
+    # here, and only a bounded number of times, with jittered exponential backoff.
+    STATUS_POLL_MAX_RETRIES = 5
+    STATUS_POLL_BACKOFF = 0.5
 
     def __init__(self, map_from: str, map_to: str = 'UniProtKB AC', verbose: bool = True,
                  session: Union[requests.Session, None] = None):
@@ -2011,10 +2018,32 @@ class GeneIDTranslator:
                 return match.group(1)
 
     @staticmethod
+    def _poll_mapping_status(session, job_id: str, verbose: bool = True):
+        """Fetch the idmapping job status, retrying transient HTTP 400s with jittered backoff.
+
+        A 400 here is (empirically) transient for a valid jobId, so retry it a bounded number of
+        times; any other error, or a 400 that never clears, is re-raised so genuine failures still
+        surface. The jitter also de-synchronizes many parallel callers that bounced together."""
+        url = f"{GeneIDTranslator.API_URL}/idmapping/status/{job_id}"
+        for attempt in range(GeneIDTranslator.STATUS_POLL_MAX_RETRIES + 1):
+            r = session.get(url)
+            try:
+                r.raise_for_status()
+            except requests.exceptions.HTTPError:
+                if r.status_code == 400 and attempt < GeneIDTranslator.STATUS_POLL_MAX_RETRIES:
+                    backoff = GeneIDTranslator.STATUS_POLL_BACKOFF * (2 ** attempt)
+                    backoff *= 0.5 + 0.5 * random.random()  # jitter
+                    if verbose:
+                        print(f"Transient error polling job status; retrying in {backoff:.1f}s")
+                    time.sleep(backoff)
+                    continue
+                raise
+            return r
+
+    @staticmethod
     def check_id_mapping_results_ready(session, job_id: str, polling_interval: float, verbose: bool = True):
         while True:
-            r = session.get(f"{GeneIDTranslator.API_URL}/idmapping/status/{job_id}")
-            r.raise_for_status()
+            r = GeneIDTranslator._poll_mapping_status(session, job_id, verbose)
             j = r.json()
             if "jobStatus" in j:
                 if j["jobStatus"] in {"RUNNING", "NEW"}:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1097,7 +1097,8 @@ def test_check_id_mapping_results_ready_running():
 
 def test_check_id_mapping_results_ready_error():
     with requests_mock.Mocker() as m:
-        # Mock the response from the server
+        # A 200 response whose jobStatus is ERROR must raise (this exercises the ERROR branch;
+        # note check_id_mapping_results_ready's signature is (session, job_id, polling_interval)).
         m.get("https://rest.uniprot.org/idmapping/status/123", json={"jobStatus": "ERROR"})
 
         # Call the function
@@ -1105,7 +1106,47 @@ def test_check_id_mapping_results_ready_error():
 
         # Check that an exception is raised
         with pytest.raises(Exception):
-            GeneIDTranslator.check_id_mapping_results_ready(session, "https://rest.uniprot.org", "123", 0.1)
+            GeneIDTranslator.check_id_mapping_results_ready(session, "123", 0.1)
+
+
+def test_check_id_mapping_results_ready_retries_transient_400(monkeypatch):
+    # UniProt's idmapping status endpoint intermittently returns a transient HTTP 400 when the
+    # job is polled before it is fully registered, or when the service is under load (e.g. many
+    # parallel CI jobs hitting it at once). Such 400s clear on a retry, so the poll must not
+    # hard-fail on the first one.
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)  # don't actually wait
+    with requests_mock.Mocker() as m:
+        adapter = m.get("https://rest.uniprot.org/idmapping/status/123",
+                        [{'status_code': 400}, {'status_code': 400}, {'json': {"results": ['content']}}])
+        session = requests.Session()
+        ready = GeneIDTranslator.check_id_mapping_results_ready(session, "123", 0.1)
+        assert ready
+        assert adapter.call_count == 3  # two 400s were retried, then the success was used
+
+
+def test_check_id_mapping_results_ready_retries_up_to_the_bound_then_succeeds(monkeypatch):
+    # A success on the very last allowed attempt must still be honoured (pins the retry bound from
+    # below: STATUS_POLL_MAX_RETRIES=5 retries -> 6 total attempts, the 6th here being the success).
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)
+    responses = [{'status_code': 400}] * GeneIDTranslator.STATUS_POLL_MAX_RETRIES + [{'json': {"results": ['x']}}]
+    with requests_mock.Mocker() as m:
+        adapter = m.get("https://rest.uniprot.org/idmapping/status/123", responses)
+        session = requests.Session()
+        ready = GeneIDTranslator.check_id_mapping_results_ready(session, "123", 0.1)
+        assert ready
+        assert adapter.call_count == GeneIDTranslator.STATUS_POLL_MAX_RETRIES + 1
+
+
+def test_check_id_mapping_results_ready_persistent_400_raises(monkeypatch):
+    # A 400 that never clears is a genuine error and must still surface after a *bounded* number of
+    # retries (pins the bound from above: exactly MAX_RETRIES+1 attempts, no infinite loop).
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)
+    with requests_mock.Mocker() as m:
+        adapter = m.get("https://rest.uniprot.org/idmapping/status/123", status_code=400)
+        session = requests.Session()
+        with pytest.raises(requests.exceptions.HTTPError):
+            GeneIDTranslator.check_id_mapping_results_ready(session, "123", 0.1)
+        assert adapter.call_count == GeneIDTranslator.STATUS_POLL_MAX_RETRIES + 1
 
 
 # Test cases for the OrthologDict class


### PR DESCRIPTION
## What & why

UniProt's idmapping **status** endpoint intermittently returns a transient `HTTP 400` for a valid `jobId` — most often when the status is polled before the job is fully registered, and much more frequently under heavy concurrent load (many parallel CI jobs, or a user running several enrichment / ID-translation analyses at once).

The session's `RandomExpRetry` adapter deliberately excludes `400` from its `status_forcelist` (a 400 is usually a genuinely bad request), so `check_id_mapping_results_ready` hard-failed on the first transient one. This is the root cause of the flaky `test_kegg_enrichment_single_list_api` failures in CI — that test performs a UniProt ID translation.

## The fix

- Extracted the status GET into `GeneIDTranslator._poll_mapping_status`, which retries a `400` a **bounded** number of times (`STATUS_POLL_MAX_RETRIES = 5`) with **jittered exponential backoff**, then re-raises.
- Genuine persistent 400s and **all** non-400 errors still surface unchanged; the `RUNNING`/`NEW`/`ERROR`/success/`failedIds` paths are untouched.
- The jitter also de-synchronizes many callers that bounced together — the correct pattern for uncoordinated clients (which is already the norm for every other external service in `io.py`; this endpoint's 400 was the one gap).

## Tests (TDD)

- `..._retries_transient_400` — two 400s then success returns `True`, asserting exactly 3 requests.
- `..._retries_up_to_the_bound_then_succeeds` — success on the last allowed attempt (pins the bound from below).
- `..._persistent_400_raises` — a never-clearing 400 raises after exactly `MAX_RETRIES + 1` attempts (pins the bound from above; no infinite loop).
- Fixed an adjacent pre-existing `..._error` test that passed the wrong positional args and so never actually reached the ERROR branch.

Reviewed by an independent clean-context agent (code verdict: correct; the review's test-hardening feedback is incorporated above). Added a `HISTORY.rst` entry under 4.2.1.

## Not in this PR (deferred)

The remaining structural lever for CI's 9× parallel API load — running the platform-independent external-API integration tests on a single job — is the tier-division revision already flagged for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)