### PR TITLE
CI: split integration tier (net/tools), add --durations, deps via uv

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -26,6 +26,9 @@ jobs:
             R_LIBS_USER: ${{ github.workspace }}/.r-libs
             # Use the faster sys.monitoring coverage backend (Python >=3.12, coverage >=7.7).
             COVERAGE_CORE: sysmon
+            # Let `uv pip install` target the actions/setup-python interpreter instead of requiring a
+            # virtualenv (see the "Install uv" / "Install dependencies" steps).
+            UV_SYSTEM_PYTHON: 1
             # Only one job (Ubuntu / Python 3.13) collects coverage; every other job runs the tests
             # without the coverage tracer, which is faster (most noticeably on Windows). This is the
             # test-runner command the tier steps below invoke.
@@ -161,25 +164,38 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
-                    cache: 'pip'
+            -   name: Install uv
+                # uv resolves + installs far faster than pip (most noticeably on Windows). It caches
+                # built wheels itself (enable-cache), so setup-python's pip cache is no longer needed.
+                uses: astral-sh/setup-uv@v9.0.0
+                with:
+                    enable-cache: true
+                    cache-dependency-glob: |
+                        requirements*.txt
+                        pyproject.toml
             -   name: Install dependencies
+                # UV_SYSTEM_PYTHON=1 (job env) makes these install into the setup-python interpreter.
                 run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install --upgrade -r requirements_dev.txt
-                    python -m pip install .[all]
+                    uv pip install --upgrade -r requirements_dev.txt
+                    uv pip install .[all]
             -   name: Prepare R library cache dir
                 # R only puts R_LIBS_USER on .libPaths() (and installs there) if the dir exists.
                 run: python -c "import os, pathlib; pathlib.Path(os.environ['R_LIBS_USER']).mkdir(parents=True, exist_ok=True)"
-            # Tests run in tiers (unit -> integration -> e2e). A failure in a faster tier stops the
-            # slower ones (fail-fast). Only the coverage job wraps them in `coverage run` (see
-            # RUN_TESTS above); every other job invokes pytest directly. Tiers are assigned
-            # automatically in tests/conftest.py; see pytest.ini for definitions.
+            # Tests run in tiers (unit -> integration_net -> integration_tools -> e2e). A failure in a
+            # faster tier stops the slower ones (fail-fast). The integration tier is split into a
+            # network/web-API step and an R/CLI-tools step so we can see the per-tier breakdown (both
+            # still run on every matrix cell for now). `--durations=25` prints the slowest tests in
+            # each tier. Only the coverage job wraps them in `coverage run` (see RUN_TESTS above);
+            # every other job invokes pytest directly. Tiers are assigned automatically in
+            # tests/conftest.py; see pytest.ini for definitions.
             -   name: Unit tests
-                run: ${{ env.RUN_TESTS }} -m unit tests/
-            -   name: Integration tests
-                run: ${{ env.RUN_TESTS }} -m integration tests/
+                run: ${{ env.RUN_TESTS }} -m unit --durations=25 tests/
+            -   name: Integration tests (network / web APIs)
+                run: ${{ env.RUN_TESTS }} -m integration_net --durations=25 tests/
+            -   name: Integration tests (R / CLI tools)
+                run: ${{ env.RUN_TESTS }} -m integration_tools --durations=25 tests/
             -   name: End-to-end (GUI) tests
-                run: ${{ env.RUN_TESTS }} -m e2e tests/
+                run: ${{ env.RUN_TESTS }} -m e2e --durations=25 tests/
             # Interactive tmate debug session on failure. Disabled by default: tmate holds the runner
             # open until the session is closed or times out, which freezes the job on every failure.
             # Re-enable on demand by setting the repository variable ENABLE_TMATE to 'true'.

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,9 +6,13 @@ qt_api=pyqt6
 addopts = --assert=plain
 markers =
     unit: fast, self-contained tests — no network, R, external CLI tools, or GUI.
-    integration: tests that hit external services (web APIs, R, kallisto/bowtie2).
+    integration: umbrella for all integration tests (union of integration_net + integration_tools).
+    integration_net: integration tests bound to external WEB services (platform-independent).
+    integration_tools: integration tests bound to external CLIs / R (exercise OS-specific binaries).
     e2e: end-to-end GUI tests (pytest-qt / qtbot).
-# Every test is auto-assigned exactly one of the tiers above by
-# tests/conftest.py::pytest_collection_modifyitems (an explicit @pytest.mark.{unit,integration,e2e}
-# always wins). Run a tier with e.g. `pytest -m unit`. CI runs them in order (unit -> integration
-# -> e2e) so a failure in a faster tier stops the slower ones (fail-fast).
+# Every test is auto-assigned a tier by tests/conftest.py::pytest_collection_modifyitems (an explicit
+# leaf-tier marker @pytest.mark.{unit,integration_net,integration_tools,e2e} always wins). Integration
+# tests carry both the umbrella `integration` marker and their leaf sub-tier, so `-m integration` still
+# selects them all. Run a tier with e.g. `pytest -m unit` or `pytest -m integration_net`. CI runs them
+# in order (unit -> integration_net -> integration_tools -> e2e) so a failure in a faster tier stops the
+# slower ones (fail-fast).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,41 @@ def pytest_configure(config):
 
 
 # --- test tiers (unit / integration / e2e) ---------------------------------------------------
-# Modules whose tests are dominated by external services (R, external CLI tools, or web APIs that
-# aren't mocked). Tests in these modules default to the `integration` tier.
-_INTEGRATION_MODULES = frozenset({
+# The `integration` tier is split into two sub-tiers so CI can time (and, later, schedule) them
+# separately:
+#   * integration_net   — bound to external WEB services; platform-independent.
+#   * integration_tools — bound to external CLIs / R; exercise OS-specific binaries.
+# Both sub-tiers also carry the umbrella `integration` marker, so `-m integration` still selects all
+# of them (back-compat with the old single tier).
+_INTEGRATION_NET_MODULES = frozenset({
     'test_io',                       # web APIs (UniProt/Ensembl/PANTHER/PhylomeDB/OrthoInspector/KEGG/GO)
+})
+_INTEGRATION_TOOLS_MODULES = frozenset({
     'test_fastq',                    # kallisto / bowtie2 / cutadapt CLIs
     'test_differential_expression',  # R (DESeq2 / limma-voom)
     'test_feature_counting',         # R (Rsubread featureCounts)
     'test_installs',                 # installs R packages
 })
-_TIER_MARKERS = ('unit', 'integration', 'e2e')
+# Leaf tiers — an explicit one of these on a test/class/module wins over auto-assignment. The
+# umbrella `integration` is intentionally NOT listed here: a test tagged only `integration` still
+# gets sub-classified into net/tools so it lands in exactly one CI step.
+_TIER_MARKERS = ('unit', 'integration_net', 'integration_tools', 'e2e')
+
+
+def _tier_markers_for(module: str, fixturenames, has_availability_skip: bool) -> tuple:
+    """Return the marker name(s) a test should carry, from its module name and traits.
+
+    Pure function (no pytest state) so it can be unit-tested directly. Integration tests get two
+    markers: the umbrella `integration` plus their leaf sub-tier. Module membership wins over the
+    availability-skip heuristic (a tools test with an 'available' skipif stays in tools).
+    """
+    if module.startswith('test_gui') or 'qtbot' in fixturenames:
+        return ('e2e',)
+    if module in _INTEGRATION_TOOLS_MODULES:
+        return ('integration', 'integration_tools')
+    if module in _INTEGRATION_NET_MODULES or has_availability_skip:
+        return ('integration', 'integration_net')
+    return ('unit',)
 
 
 def _has_availability_skip(item) -> bool:
@@ -38,20 +63,17 @@ def _has_availability_skip(item) -> bool:
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-assign every test to exactly one tier (unit / integration / e2e).
+    """Auto-assign every test to a tier (unit / integration_net / integration_tools / e2e).
 
-    An explicit @pytest.mark.{unit,integration,e2e} on the test/class/module always wins; this only
-    fills in a tier for tests that don't declare one. See pytest.ini for the tier definitions.
+    An explicit leaf-tier marker (@pytest.mark.{unit,integration_net,integration_tools,e2e}) on the
+    test/class/module always wins; this only fills in a tier for tests that don't declare one.
+    Integration tests additionally carry the umbrella `integration` marker. See pytest.ini.
     """
     for item in items:
         if any(item.get_closest_marker(m) for m in _TIER_MARKERS):
-            continue  # respect an explicit tier
+            continue  # respect an explicit leaf tier
 
         module = item.module.__name__.rsplit('.', 1)[-1] if item.module is not None else ''
-        if module.startswith('test_gui') or 'qtbot' in getattr(item, 'fixturenames', ()):
-            tier = 'e2e'
-        elif module in _INTEGRATION_MODULES or _has_availability_skip(item):
-            tier = 'integration'
-        else:
-            tier = 'unit'
-        item.add_marker(getattr(pytest.mark, tier))
+        markers = _tier_markers_for(module, getattr(item, 'fixturenames', ()), _has_availability_skip(item))
+        for marker in markers:
+            item.add_marker(getattr(pytest.mark, marker))

--- a/tests/test_tiering.py
+++ b/tests/test_tiering.py
@@ -1,0 +1,29 @@
+"""Unit tests for the CI test-tier auto-classification in conftest.py (`_tier_markers_for`)."""
+import pytest
+
+from tests.conftest import _tier_markers_for
+
+
+@pytest.mark.parametrize('module,fixturenames,availability_skip,expected', [
+    # GUI modules and any qtbot-using test -> e2e
+    ('test_gui', (), False, ('e2e',)),
+    ('test_gui_windows', (), False, ('e2e',)),
+    ('test_filtering', ('qtbot',), False, ('e2e',)),
+    # web-API module -> integration_net (with umbrella)
+    ('test_io', (), False, ('integration', 'integration_net')),
+    # a live-network test in an otherwise-mocked module (availability skipif) -> net
+    ('test_enrichment', (), True, ('integration', 'integration_net')),
+    # CLI / R modules -> integration_tools (with umbrella)
+    ('test_fastq', (), False, ('integration', 'integration_tools')),
+    ('test_differential_expression', (), False, ('integration', 'integration_tools')),
+    ('test_feature_counting', (), False, ('integration', 'integration_tools')),
+    ('test_installs', (), False, ('integration', 'integration_tools')),
+    # module membership wins over the availability-skip heuristic (tools stays tools)
+    ('test_fastq', (), True, ('integration', 'integration_tools')),
+    # everything else -> unit
+    ('test_filtering', (), False, ('unit',)),
+    ('test_enrichment', (), False, ('unit',)),
+    ('', (), False, ('unit',)),
+])
+def test_tier_markers_for(module, fixturenames, availability_skip, expected):
+    assert _tier_markers_for(module, fixturenames, availability_skip) == expected


### PR DESCRIPTION
Stacked on top of #85 (`fix/uniprot-status-poll-retry`). Base auto-retargets to `development` when #85 merges.

Continues the CI-speedup work. Measured baseline: the **integration tier dominates** wall-clock (~794s on macOS/3.14 vs 81s unit / 58s e2e) and runs on all 9 matrix cells.

## Changes
- **Split `integration` into two sub-tiers** via a pure, unit-tested helper `_tier_markers_for` in `tests/conftest.py`:
  - `integration_net` — web APIs (`test_io`) + live `skipif *_AVAILABLE` enrichment tests (platform-independent).
  - `integration_tools` — R + kallisto/bowtie2 (`test_fastq`, `test_differential_expression`, `test_feature_counting`, `test_installs`).
  - Both keep the umbrella **`integration`** marker, so `-m integration` still selects everything (back-compat).
- **Run both sub-tiers as separate CI steps on every matrix cell** — purely to reveal the per-platform net-vs-tools breakdown. No per-OS reduction yet; that's the intended follow-up once the durations confirm the split.
- **`--durations=25`** on all four test steps (unit / net / tools / e2e) for per-test timing.
- **Install CI deps with `astral-sh/setup-uv@v9.0.0`** (`uv pip install`, `UV_SYSTEM_PYTHON: 1`) instead of pip; drop the now-redundant setup-python pip cache. Biggest expected win on Windows (dep install was 209–260s).
- New `tests/test_tiering.py` (13 cases) covering the classification.

## Testing
- `tests/test_tiering.py` — passes locally (13/13).
- Verified marker selection via `--collect-only`: the 23 `test_differential_expression` tests appear under both `integration` and `integration_tools` (not net/unit/e2e); all 364 `test_filtering` tests are `unit`-only.
- **Not runnable locally:** the R/CLI/network integration tiers, the e2e GUI tier, and the uv install path — those get exercised for the first time on GitHub Actions here. The tiering *logic* is fully covered by the unit test + collection checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)