### PR TITLE
Add AGENTS.md provider-neutral agent guide; link from CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md — working in RNAlysis with an AI agent
+
+Provider-neutral entry point for **any** AI coding agent or automated contributor
+(Claude, Cursor, Aider, GitHub Copilot, Codex, Windsurf, Gemini, custom bots, …) working in
+this repository. It follows the [agents.md](https://agents.md) convention.
+
+**The full working guide is [`CLAUDE.md`](CLAUDE.md).** Despite the name it is written for
+*all* agents, not only Claude Code — it holds the complete repository map, the API↔GUI
+reflection contract, the command list, the style rules, and the known gotchas. Read it. Deeper
+material lives in [`.claude/context.md`](.claude/context.md),
+[`.claude/workflows.md`](.claude/workflows.md), and
+[`.claude/design-philosophy.md`](.claude/design-philosophy.md). Human contributors should also
+read [`CONTRIBUTING.rst`](CONTRIBUTING.rst).
+
+What follows is the short version: the one architectural idea you must understand before
+changing anything, and the non-negotiable rules. If you read nothing else here, read this — but
+prefer reading `CLAUDE.md` in full.
+
+---
+
+## What RNAlysis is
+
+Desktop software that lets biologists analyze RNA-sequencing data — from raw FASTQ through
+filtering, normalization, differential expression, clustering, and enrichment — **without
+writing any code**. It ships a PyQt6 graphical app and a programmatic Python API, and targets
+scientists with **zero programming experience**. Correctness and reproducibility are
+non-negotiable.
+
+---
+
+## The one idea to understand first: the API↔GUI reflection contract
+
+**The programmatic Python API is the source of truth. The GUI is generated from it by
+reflection.** When you add a public method to a `Filter`/`FeatureSet` subclass (or a public
+function in `fastq`/`enrichment`), the GUI **auto-discovers and renders it** — you do not write
+Qt code for it. What drives that rendering:
+
+- **Type annotations are load-bearing UI.** Each parameter's annotation maps to a specific Qt
+  widget (e.g. `bool` → toggle, `Fraction` → 0–1 slider, `Color` → color picker,
+  `Literal[...]` → combo box, `Optional[T]` → a checkbox that enables a `T` widget). The custom
+  types live in `rnalysis/utils/param_typing.py`. **Choosing the right annotation is how you
+  design the GUI.**
+- **Docstrings are load-bearing help text.** The reST `:param x: ...` lines become the
+  per-parameter tooltips; keep that format.
+- **`@readable_name('…')`** sets the human-readable button/window label.
+
+**Consequence:** renaming a public method, changing its signature, or loosening a type
+annotation silently changes the GUI (and possibly serialized parameters). Treat any such change
+as *risky*. The full contract — discovery heuristics, the complete annotation→widget table, and
+how to hide internals — is in [`CLAUDE.md`](CLAUDE.md).
+
+---
+
+## Non-negotiable rules
+
+Hard invariants. Do not violate them without explicit sign-off from a maintainer.
+
+1. **Test-driven development, always.** Write a failing test first, make it pass, then refactor.
+   New code must be covered. Run the *relevant* `tests/test_*.py` module(s) before calling
+   anything done, and state plainly what you could **not** run (paths needing R, network,
+   kallisto/bowtie2, or a Qt display).
+2. **Branch model: feature branch → `development` → `master`.** `development` is the long-lived
+   integration branch; `master` is stable/released and only receives `development` at a version
+   release. **Never commit directly to `master` or `development`.** Cut a feature/fix branch off
+   `development` and open your PR **into `development`**.
+3. **Plan first for risky changes.** If a change touches a public API signature, the API→GUI
+   reflection contract, or a serialized format (Pipeline YAML / session file / exported
+   parameters), propose a short plan and wait for approval before coding. Small localized fixes:
+   just do it (TDD) and show the diff.
+4. **Back-compat of serialized artifacts is a hard invariant.** Old Pipeline YAMLs, saved
+   sessions, and exported parameter files **must keep loading** in new versions. Breaking this
+   is a bug — flag it loudly.
+5. **Results must reproduce across versions.** A given analysis with given parameters must
+   produce the same output. If a change alters numerical output, it must be intentional,
+   justified, and called out in `HISTORY.rst`.
+6. **Every new function needs reasonable defaults.** Assume a non-programmer, non-bioinformatician
+   user; defaults should produce a sensible, correct analysis out of the box.
+7. **Cross-platform or it doesn't ship.** Must work on Windows, macOS, and Linux, both
+   run-from-source **and** frozen (PyInstaller). Mind the multiprocessing/frozen split described
+   in `CLAUDE.md`.
+8. **Independent review before done.** At PR time, have an agent or reviewer with clean context
+   — not the one that wrote the change — review the diff, and address the findings.
+
+---
+
+## Fast start
+
+```bash
+pip install -e .[all]                      # install for development
+pip install -r requirements_dev.txt        # pytest, pytest-qt, etc.
+
+rnalysis-gui                               # run the app (installed entry point)
+
+pytest tests/test_filtering.py             # run one module while iterating
+pytest tests/test_filtering.py -k <name>   # run a subset of a module
+```
+
+The full command list, the CI matrix, the repository map, the style rules, and the
+external-API / multiprocessing / Qt-flakiness gotchas are all in [`CLAUDE.md`](CLAUDE.md). A few
+things worth stating up front: don't hand-edit generated files (`docs/source/rnalysis.*.rst`
+come from `sphinx-apidoc`), and prefer **Polars** over Pandas for tabular work (the codebase
+migrated off Pandas in 4.0).
+
+---
+
+## A note on tool-specific instructions
+
+`CLAUDE.md` refers to Claude Code "skills" (`tdd`, `diagnosing-bugs`, `code-review`,
+`research`). Those are convenience shortcuts for one particular tool — but the *workflows they
+encode* apply to every agent: disciplined TDD, methodical debugging, a clean-context review of
+each diff, and verifying an external API's real current behavior before coding against it. Use
+whatever tooling you have to achieve the same outcomes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,11 @@ Operational guide for Claude Code (and any AI/agent) working in this repository.
 Read this first. Deeper material lives in [`.claude/context.md`](.claude/context.md),
 [`.claude/workflows.md`](.claude/workflows.md), and [`.claude/design-philosophy.md`](.claude/design-philosophy.md).
 
+> **Not using Claude Code?** This guide applies to you too. [`AGENTS.md`](AGENTS.md) is the
+> provider-neutral entry point for any AI agent or automated contributor — it distills the
+> non-negotiable rules and points back here for the full detail. `CLAUDE.md` (this file) is the
+> canonical, complete version; keep the two in sync when you change the rules.
+
 ---
 
 ## What RNAlysis is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,6 @@ CI (`.github/workflows/build_ci.yml`) runs on every PR across
 - **Docstrings are load-bearing** (they become GUI help). Keep the `:param name: ...` /
   `:type name: ...` reST format when editing public functions.
 - **`docs/source/rnalysis.*.rst` are generated** by `sphinx-apidoc`. Don't hand-edit them.
-- **`CONTRIBUTING.rst` is partly stale** (mentions Py 3.7–3.10, tox, Travis). Reality: Py
-  3.10–3.15, GitHub Actions, no `tox.ini`. Trust this file and CI over `CONTRIBUTING.rst`.
 
 ---
 


### PR DESCRIPTION
## Why

Since we started opening small issues, more people have been contributing with the help of AI coding agents — and not all of them use Claude Code. Repo guidance currently lives only in `CLAUDE.md`, which non-Claude agents won't discover by convention.

## What

- **New `AGENTS.md`** — the provider-neutral entry point (the [agents.md](https://agents.md) convention that Cursor, Aider, Codex, Copilot, Windsurf, Gemini, etc. look for). It's self-sufficient for the essentials: it inlines the **non-negotiable rules** (TDD, branch model, plan-first, serialized back-compat, reproducibility, sensible defaults, cross-platform+frozen, clean-context review) and the **API↔GUI reflection contract**, then routes to `CLAUDE.md` and the `.claude/*.md` docs for the full detail.
- **`CLAUDE.md`** — a short cross-link near the top pointing non-Claude agents to `AGENTS.md`.

## Design choice: single source of truth, no drift

`AGENTS.md` deliberately does **not** duplicate the volatile content (repo map, full command list, gotchas) — those stay only in `CLAUDE.md`, referenced not copied. `AGENTS.md` inlines only the stable "constitution" (the hard rules), so the two files won't drift apart as the repo evolves. `CLAUDE.md` remains the canonical, complete version.

## Notes

- Docs-only change; no code, no tests affected, no `HISTORY.rst`/`README.rst` entry needed.
- Branched off `development`, targets `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)