### PR TITLE
Follow-up to #87: tier-comment accuracy, type hints, uv-pin note

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -167,6 +167,8 @@ jobs:
             -   name: Install uv
                 # uv resolves + installs far faster than pip (most noticeably on Windows). It caches
                 # built wheels itself (enable-cache), so setup-python's pip cache is no longer needed.
+                # Pinned to a full version on purpose: setup-uv no longer publishes a moving `@v9` major
+                # tag, so `@v9.0.0` (not `@v9`) is the correct current pin.
                 uses: astral-sh/setup-uv@v9.0.0
                 with:
                     enable-cache: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Iterable, Tuple
 
 import pytest
 
@@ -29,12 +30,15 @@ _INTEGRATION_TOOLS_MODULES = frozenset({
     'test_installs',                 # installs R packages
 })
 # Leaf tiers — an explicit one of these on a test/class/module wins over auto-assignment. The
-# umbrella `integration` is intentionally NOT listed here: a test tagged only `integration` still
-# gets sub-classified into net/tools so it lands in exactly one CI step.
+# umbrella `integration` is intentionally NOT listed here, so tagging it never suppresses
+# auto-assignment: classification keys off the module name, and each integration module maps to
+# exactly one leaf sub-tier (net or tools). (A bare `@pytest.mark.integration` isn't used anywhere in
+# the suite; such a test would be classified by its module like any other.)
 _TIER_MARKERS = ('unit', 'integration_net', 'integration_tools', 'e2e')
 
 
-def _tier_markers_for(module: str, fixturenames, has_availability_skip: bool) -> tuple:
+def _tier_markers_for(module: str, fixturenames: Iterable[str],
+                      has_availability_skip: bool) -> Tuple[str, ...]:
     """Return the marker name(s) a test should carry, from its module name and traits.
 
     Pure function (no pytest state) so it can be unit-tested directly. Integration tests get two


### PR DESCRIPTION
Small follow-up carrying the clean-context review nits for PR #87, which merged into `development` before these were applied. No functional change.

- **conftest.py** — correct the misleading comment about the umbrella `integration` marker (auto-classification keys off the *module name*; a bare `@pytest.mark.integration` isn't sub-classified, and isn't used anywhere in the suite). Fully annotate `_tier_markers_for` (`Iterable[str]` / `Tuple[str, ...]`).
- **build_ci.yml** — note that `astral-sh/setup-uv@v9.0.0` is a deliberate full-version pin (setup-uv no longer publishes a moving `@v9` major tag).

`tests/test_tiering.py` still passes (13/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)