### PR TITLE
CI: run integration_net tests on only the coverage runner

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -185,14 +185,21 @@ jobs:
                 run: python -c "import os, pathlib; pathlib.Path(os.environ['R_LIBS_USER']).mkdir(parents=True, exist_ok=True)"
             # Tests run in tiers (unit -> integration_net -> integration_tools -> e2e). A failure in a
             # faster tier stops the slower ones (fail-fast). The integration tier is split into a
-            # network/web-API step and an R/CLI-tools step so we can see the per-tier breakdown (both
-            # still run on every matrix cell for now). `--durations=25` prints the slowest tests in
-            # each tier. Only the coverage job wraps them in `coverage run` (see RUN_TESTS above);
-            # every other job invokes pytest directly. Tiers are assigned automatically in
-            # tests/conftest.py; see pytest.ini for definitions.
+            # network/web-API step and an R/CLI-tools step so we can see the per-tier breakdown.
+            # `--durations=25` prints the slowest tests in each tier. Only the coverage job wraps them
+            # in `coverage run` (see RUN_TESTS above); every other job invokes pytest directly. Tiers
+            # are assigned automatically in tests/conftest.py; see pytest.ini for definitions.
             -   name: Unit tests
                 run: ${{ env.RUN_TESTS }} -m unit --durations=25 tests/
+            # The network/web-API tests just hit external services (UniProt/Ensembl/PANTHER/
+            # PhylomeDB/KEGG/GO), so their results are platform-independent and running them on all 9
+            # matrix cells is redundant. Worse, 9 concurrent runners hammering rate-limited services
+            # (esp. UniProt idmapping) causes transient failures. Run them only on the coverage cell
+            # (ubuntu-latest / 3.13, matching RUN_TESTS above) to cut external-API load 9x -> 1x with
+            # no loss of coverage. On the other 8 cells this step is skipped; integration_tools/e2e
+            # still run (a skipped step keeps success() true, so it doesn't fail the job).
             -   name: Integration tests (network / web APIs)
+                if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }}
                 run: ${{ env.RUN_TESTS }} -m integration_net --durations=25 tests/
             -   name: Integration tests (R / CLI tools)
                 run: ${{ env.RUN_TESTS }} -m integration_tools --durations=25 tests/


### PR DESCRIPTION
## What

Gate the **"Integration tests (network / web APIs)"** step (`-m integration_net`) in `.github/workflows/build_ci.yml` with:

```yaml
if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }}
```

so it runs on **only one** matrix cell — the same one that collects coverage — instead of all 9. `unit`, `integration_tools`, and `e2e` are unchanged and still run on all 9 cells.

## Why

The `integration_net` tests hit external web APIs (UniProt / Ensembl / PANTHER / PhylomeDB / KEGG / GO) and are **platform-independent**, so running them 9× is redundant. Worse, 9 concurrent runners hammering rate-limited services (especially UniProt idmapping) cause transient failures — e.g. PR #85's `test_kegg_enrichment_single_list_api` returning a 400 on `rest.uniprot.org/idmapping/status`.

Running them once:
- cuts external-API load **9× → 1×**, which should kill that rate-limit flakiness;
- saves time on the other 8 jobs (they skip the network tier);
- loses **no** coverage — the tests are platform-independent and the single cell chosen is the coverage cell.

This is the deferred "integration_net ×1" structural fix from the CI-perf plan.

## Fail-fast behavior

Tiers run sequentially per job: `unit → integration_net → integration_tools → e2e`.
- On the **8 non-coverage cells**, the net step is skipped. A skipped step keeps `success()` true, so `integration_tools` and `e2e` still run and the job isn't failed by the skip.
- On the **coverage cell** (ubuntu-latest / 3.13) all four tiers run in order, preserving fail-fast within that cell.

The `if:` condition is matched to the existing coverage-job selector used by the `RUN_TESTS` env var and the `Generate lcov` / `Coveralls Parallel` steps.

## Testing

CI cannot be validated locally — the real validation is this PR's own CI run. Locally I confirmed the workflow still parses:

```
python -c "import yaml; yaml.safe_load(open('.github/workflows/build_ci.yml', encoding='utf-8')); print('ok')"  # -> ok
```

Please confirm on the CI run that the network tier executes only on the ubuntu-latest / 3.13 cell and is skipped (not failed) on the other 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
