### PR TITLE
CI: breadcrumb to name the test behind a native crash (flaky GUI diagnosis)

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -33,6 +33,11 @@ jobs:
             # without the coverage tracer, which is faster (most noticeably on Windows). This is the
             # test-runner command the tier steps below invoke.
             RUN_TESTS: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13') && 'coverage run --append --source=rnalysis/ -m pytest' || 'python -m pytest' }}
+            # A native crash (e.g. the flaky Qt access violation in the e2e tier) kills the process
+            # without pytest reporting which test was running. tests/conftest.py writes each test's
+            # nodeid here before it runs, so the "Report last test before a crash" step below can name
+            # the culprit. No effect on runs where this env var is unset (e.g. local runs).
+            PYTEST_CRASH_BREADCRUMB: ${{ github.workspace }}/pytest_last_test.txt
         steps:
             -   name: Configure pagefile
                 if: runner.os == 'Windows'
@@ -198,6 +203,18 @@ jobs:
                 run: ${{ env.RUN_TESTS }} -m integration_tools --durations=25 tests/
             -   name: End-to-end (GUI) tests
                 run: ${{ env.RUN_TESTS }} -m e2e --durations=25 tests/
+            -   name: Report last test before a crash
+                # Runs whenever a prior tier failed (incl. a native crash that produced no pytest
+                # summary). Surfaces the breadcrumb written by tests/conftest.py so the flaky e2e crash
+                # names the exact test instead of an anonymous "access violation".
+                if: failure()
+                shell: bash
+                run: |
+                    if [ -f "${GITHUB_WORKSPACE}/pytest_last_test.txt" ]; then
+                        echo "::warning::Last test started before failure/crash: $(cat "${GITHUB_WORKSPACE}/pytest_last_test.txt")"
+                    else
+                        echo "No crash breadcrumb file was written."
+                    fi
             # Interactive tmate debug session on failure. Disabled by default: tmate holds the runner
             # open until the session is closed or times out, which freezes the job on every failure.
             # Re-enable on demand by setting the repository variable ENABLE_TMATE to 'true'.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,25 @@ def pytest_configure(config):
     os.environ["QT_DEBUG_PLUGINS"] = "1"
 
 
+def pytest_runtest_logstart(nodeid, location):
+    """Write the about-to-run test's nodeid to a breadcrumb file, if PYTEST_CRASH_BREADCRUMB is set.
+
+    A native crash (e.g. the flaky Qt access violation in the e2e tier) kills the process without
+    pytest reporting which test was running. Recording the nodeid *before* each test runs means the
+    file's last value identifies the culprit after a crash (see the CI "Report last test before a
+    crash" step). No-op unless the env var is set, so it costs nothing on local/normal runs.
+    """
+    breadcrumb = os.environ.get("PYTEST_CRASH_BREADCRUMB")
+    if not breadcrumb:
+        return
+    try:
+        with open(breadcrumb, "w", encoding="utf-8") as handle:
+            handle.write(f"{nodeid}\n")
+            handle.flush()
+    except OSError:
+        pass
+
+
 # --- test tiers (unit / integration / e2e) ---------------------------------------------------
 # The `integration` tier is split into two sub-tiers so CI can time (and, later, schedule) them
 # separately:


### PR DESCRIPTION
**Instrument-first** step for the flaky e2e GUI crash (`Windows fatal exception: access violation`), which we caught for the first time now that the tier split lets the e2e tier run. A native crash kills the process without pytest reporting *which* test was running — the faulthandler trace only shows pytest internals.

## What this adds (diagnostic only, no behavior change)
- **`tests/conftest.py`** — a `pytest_runtest_logstart` hook writes each test's nodeid to the file named by `PYTEST_CRASH_BREADCRUMB`, *before* the test runs. No-op unless that env var is set (local/normal runs unaffected).
- **`build_ci.yml`** — sets `PYTEST_CRASH_BREADCRUMB` and adds an `if: failure()` step that echoes the last recorded nodeid as a `::warning::`. So the next crash names the exact test instead of an anonymous access violation.

## Diagnosis so far (context for reviewers)
- Reconstructing the CI seed (`pytest-randomly` 2655067149) pointed at `test_MainWindow_new_table_from_folder_htseqcount[False]` as where it crashed — but that test passes 15/15 in isolation locally, so it's a *manifestation point*, not the cause.
- **Root-cause candidate:** `MainWindow.closeEvent` (`gui.py:4413`) calls `.quit()` on `job_thread` and the stdout-listener `QThread` (lines 4426/4430) with **no `.wait()`**. The `main_window*` fixtures `close()` the window each test, so threads can outlive it and crash a *later* test's `_process_events`. Timing/platform-dependent → flaky, 3.14/Qt-6.11, CI-only.
- The teardown fix (make the stdout listener interruptible, then quit+wait both threads) is the planned **follow-up** — this PR lands the instrumentation first so we can confirm the culprit and get a before/after signal.

## Testing
- Verified locally: with `PYTEST_CRASH_BREADCRUMB` set, the file holds the last-run test's nodeid after a run; unset, the hook is a no-op. `build_ci.yml` YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)