### PR TITLE
Fix flaky GUI crash: wait for worker threads on close

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Fixed
 * Fixed a bug in ``CountFilter.pairplot`` where the Spearman correlation shown for the first row/column of the plot was computed against the gene-index column instead of a sample, producing an incorrect value (and, with recent NumPy versions, an error). The correlations are now always computed between the correct pair of samples.
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
 * Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.
+* Fixed a bug where closing the RNAlysis window could occasionally crash the application, because its background worker and console threads were signalled to stop but not waited for before the window was destroyed. Closing now shuts those threads down cleanly first.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -3041,9 +3041,6 @@ class MainWindow(QtWidgets.QMainWindow):
     FEATURE_URL = 'https://github.com/GuyTeichman/RNAlysis/issues/new?assignees=&labels=feature+request&projects=' \
                   '&template=feature_request.yaml&title=Feature+Request%3A+'
     QUESTION_URL = 'https://github.com/GuyTeichman/RNAlysis/discussions'
-    #: Upper bound (ms) on how long closing waits for the job thread to finish an in-flight worker
-    #: before giving up, so a long-running analysis can't freeze the app on close.
-    JOB_THREAD_SHUTDOWN_TIMEOUT_MS = 10_000
 
     jobQueued = QtCore.pyqtSignal()
 
@@ -4420,9 +4417,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
         The STDOUT listener's ``run()`` blocks on ``queue_stdout.get()`` and never returns to its
         event loop, so ``quit()`` alone can't stop it (and a bare ``wait()`` would hang forever).
-        Enqueue ``STOP_SIGNAL`` first to break that loop, then ``quit()`` + ``wait()``. The job
-        thread runs finite workers that quit it on completion, so it only needs ``quit()`` + a
-        bounded ``wait()`` (bounded so closing during a long-running job can't freeze the app).
+        Enqueue ``STOP_SIGNAL`` first to break that loop, then ``quit()`` + ``wait()``.
+
+        Both waits are unbounded on purpose. When the threads are idle (the common case, and every
+        e2e-test teardown) they return immediately. If a worker is still mid-run we wait for it to
+        finish rather than (a) abandon its thread -- the very crash this fixes -- or (b)
+        ``terminate()`` it, which Qt documents as unsafe (it can strand a held mutex/GIL and corrupt
+        state). A user who force-quits during a long job just kills the process, which the OS reclaims
+        without triggering the C++ "destroyed while running" crash.
         """
         listener = getattr(self, 'thread_stdout_queue_listener', None)
         if listener is not None:
@@ -4435,7 +4437,7 @@ class MainWindow(QtWidgets.QMainWindow):
         job_thread = getattr(self, 'job_thread', None)
         if job_thread is not None:
             job_thread.quit()
-            job_thread.wait(self.JOB_THREAD_SHUTDOWN_TIMEOUT_MS)
+            job_thread.wait()
 
     def closeEvent(self, event):  # pragma: no cover
 

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -3041,6 +3041,9 @@ class MainWindow(QtWidgets.QMainWindow):
     FEATURE_URL = 'https://github.com/GuyTeichman/RNAlysis/issues/new?assignees=&labels=feature+request&projects=' \
                   '&template=feature_request.yaml&title=Feature+Request%3A+'
     QUESTION_URL = 'https://github.com/GuyTeichman/RNAlysis/discussions'
+    #: Upper bound (ms) on how long closing waits for the job thread to finish an in-flight worker
+    #: before giving up, so a long-running analysis can't freeze the app on close.
+    JOB_THREAD_SHUTDOWN_TIMEOUT_MS = 10_000
 
     jobQueued = QtCore.pyqtSignal()
 
@@ -4410,6 +4413,30 @@ class MainWindow(QtWidgets.QMainWindow):
             return dialog.result()
         return None
 
+    def _shutdown_worker_threads(self):
+        """Stop the background QThreads cleanly so no QThread object is destroyed while its OS
+        thread is still running -- that teardown race is the flaky "Windows fatal exception:
+        access violation" seen in the e2e tier.
+
+        The STDOUT listener's ``run()`` blocks on ``queue_stdout.get()`` and never returns to its
+        event loop, so ``quit()`` alone can't stop it (and a bare ``wait()`` would hang forever).
+        Enqueue ``STOP_SIGNAL`` first to break that loop, then ``quit()`` + ``wait()``. The job
+        thread runs finite workers that quit it on completion, so it only needs ``quit()`` + a
+        bounded ``wait()`` (bounded so closing during a long-running job can't freeze the app).
+        """
+        listener = getattr(self, 'thread_stdout_queue_listener', None)
+        if listener is not None:
+            queue_stdout = getattr(self, 'queue_stdout', None)
+            receiver = getattr(self, 'stdout_receiver', None)
+            if queue_stdout is not None and receiver is not None:
+                queue_stdout.put(receiver.STOP_SIGNAL)
+            listener.quit()
+            listener.wait()
+        job_thread = getattr(self, 'job_thread', None)
+        if job_thread is not None:
+            job_thread.quit()
+            job_thread.wait(self.JOB_THREAD_SHUTDOWN_TIMEOUT_MS)
+
     def closeEvent(self, event):  # pragma: no cover
 
         quit_msg = "Are you sure you want to close <i>RNAlysis</i>?\n" \
@@ -4421,15 +4448,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             plt.close('all')
-            # quit job and STDOUT listener threads
-            try:
-                self.job_thread.quit()
-            except AttributeError:
-                pass
-            try:
-                self.thread_stdout_queue_listener.quit()
-            except AttributeError:
-                pass
+            # stop background threads cleanly before the window (and its QThread members) are
+            # destroyed, so neither QThread object is torn down while its OS thread is still running.
+            self._shutdown_worker_threads()
             # clear cache
             io.clear_gui_cache()
             # close all figures

--- a/rnalysis/gui/gui_widgets.py
+++ b/rnalysis/gui/gui_widgets.py
@@ -1804,6 +1804,9 @@ class QMultiToggleSwitch(QMultiInput):
 class ThreadStdOutStreamTextQueueReceiver(QtCore.QObject):
     queue_stdout_element_received_signal = QtCore.pyqtSignal(str)
     __slots__ = {'queue': 'queue'}
+    #: Sentinel put on the queue to break run()'s blocking loop so the listener thread can end.
+    #: Compared by identity, so it can never collide with a real (string) stdout item.
+    STOP_SIGNAL = object()
 
     def __init__(self, q: Queue, *args, **kwargs):
         QtCore.QObject.__init__(self, *args, **kwargs)
@@ -1814,6 +1817,8 @@ class ThreadStdOutStreamTextQueueReceiver(QtCore.QObject):
         self.queue_stdout_element_received_signal.emit('Welcome to RNAlysis!\n')
         while True:
             text = self.queue.get()
+            if text is self.STOP_SIGNAL:  # graceful shutdown (see MainWindow._shutdown_worker_threads)
+                break
             self.queue_stdout_element_received_signal.emit(text)
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2241,6 +2241,19 @@ def test_MainWindow_init(main_window):
     _ = main_window
 
 
+def test_MainWindow_shutdown_worker_threads_stops_threads(main_window):
+    """closeEvent must leave no QThread running: quit()+wait() so neither QThread object is
+    destroyed while its OS thread is still running (the flaky Windows access-violation crash)."""
+    # the STDOUT listener thread is started at construction (gather_stdout=True)
+    assert main_window.thread_stdout_queue_listener.isRunning()
+
+    main_window._shutdown_worker_threads()
+
+    # wait() inside the helper guarantees the OS threads have finished before it returns
+    assert not main_window.thread_stdout_queue_listener.isRunning()
+    assert not main_window.job_thread.isRunning()
+
+
 def test_MainWindow_add_new_tab(main_window):
     main_window.new_table_action.trigger()
     assert main_window.tabs.count() == 2

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2254,6 +2254,35 @@ def test_MainWindow_shutdown_worker_threads_stops_threads(main_window):
     assert not main_window.job_thread.isRunning()
 
 
+def test_MainWindow_shutdown_worker_threads_waits_for_running_job(main_window, qtbot):
+    """A worker still running at close must be waited for (not abandoned -> the crash this fixes).
+    Proven by the job's side effect completing and the thread stopping after the helper returns."""
+    import time
+
+    finished = []
+
+    class _BlockingWorker(QtCore.QObject):
+        # mirrors the real setup: a worker moved to the job thread, run() wired to started, so the
+        # body executes *in* that thread (as opposed to a bare function, which queues to the caller)
+        @QtCore.pyqtSlot()
+        def run(self):
+            time.sleep(0.2)
+            finished.append(True)
+
+    thread = QtCore.QThread()
+    worker = _BlockingWorker()
+    worker.moveToThread(thread)
+    thread.started.connect(worker.run)
+    main_window.job_thread = thread
+    thread.start()
+    qtbot.waitUntil(thread.isRunning, timeout=2000)
+
+    main_window._shutdown_worker_threads()
+
+    assert finished == [True]           # the in-flight job ran to completion -> we actually waited
+    assert not thread.isRunning()
+
+
 def test_MainWindow_add_new_tab(main_window):
     main_window.new_table_action.trigger()
     assert main_window.tabs.count() == 2

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -1490,3 +1490,24 @@ class TestLRTPickerGroup:
 
         widget.inputs[1].factor.setCurrentText('covariate1+covariate1^2')
         assert widget.get_comparison_values() == ['condition', 'poly(covariate1, degree = 2)']
+
+
+def test_ThreadStdOutStreamTextQueueReceiver_run_stops_on_sentinel(qtbot):
+    """run() blocks on queue.get(); enqueueing STOP_SIGNAL must break the loop so the thread ends.
+
+    Regression guard for the flaky e2e native crash: if the listener loop can't be stopped, a
+    quit()+wait() teardown would hang, and skipping wait() (the old behaviour) lets the QThread be
+    destroyed while its OS thread is still running -> "Windows fatal exception: access violation".
+    """
+    import threading
+
+    q = Queue()
+    receiver = ThreadStdOutStreamTextQueueReceiver(q)
+    thread = threading.Thread(target=receiver.run, daemon=True)
+    thread.start()
+
+    q.put('ordinary console output')      # a normal item -> loop keeps going
+    q.put(receiver.STOP_SIGNAL)           # sentinel -> loop must return
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()


### PR DESCRIPTION
## What & why

Fixes the long-standing flaky e2e crash (**\"Windows fatal exception: access violation\"**) that CLAUDE.md flags as unresolved and that we finally *caught* in CI once the tier split let the e2e tier run (breadcrumb instrumentation landed in #94).

**Root cause (teardown race, not a buggy test):** `MainWindow.closeEvent` signalled both background `QThread`s to stop with `quit()` but never `wait()`ed. `quit()` only asks a thread's event loop to exit and returns immediately, so when the window was garbage-collected its `QThread` **objects could be destroyed while their OS threads were still running** → Qt's *\"QThread: Destroyed while thread is still running\"* → native access violation during pytest-qt's post-test `_process_events`. Timing/platform-dependent → flaky → CI-only. The manifestation point (`test_MainWindow_new_table_from_folder_htseqcount`) passes 15/15 in isolation, confirming it's the cross-test thread lifetime, not that test.

> Note: the e2e tests monkeypatch the listener's `run` to a no-op, so in the test environment the mechanism is purely the *quit-without-wait race*. The blocked `queue.get()` only bites the **real app** — which is why the fix still needs the sentinel (a bare `wait()` would hang real users on close).

## The fix

- **Interruptible listener** — `ThreadStdOutStreamTextQueueReceiver.run()` blocks forever on `queue.get()`, so a naive `wait()` would hang the real app on close. Added a `STOP_SIGNAL` sentinel (identity-compared → can't collide with a real string stdout item) that breaks the loop.
- **`MainWindow._shutdown_worker_threads()`** — enqueues the sentinel, then `quit()`+`wait()`s the STDOUT listener and the job thread. `closeEvent` calls this instead of the two bare `quit()`s.
- **Both waits are unbounded, on purpose.** Idle threads (the common case, and every e2e teardown) return immediately; a genuine in-flight worker is waited for rather than abandoned. `terminate()` is deliberately avoided — Qt documents it as unsafe (can strand a held mutex/GIL). A user who force-quits during a long job just kills the process, which the OS reclaims without the C++ crash.

## Tests (TDD, red→green)

- `test_ThreadStdOutStreamTextQueueReceiver_run_stops_on_sentinel` — **deterministic**: runs `run()` in a thread, asserts it returns once `STOP_SIGNAL` is enqueued.
- `test_MainWindow_shutdown_worker_threads_stops_threads` — asserts both threads are *not running* after the helper returns.
- `test_MainWindow_shutdown_worker_threads_waits_for_running_job` — moves a blocking worker onto the job thread, starts it, and asserts the in-flight job runs to completion and the thread stops (exercises the wait-for-running-thread path).

Locally: all three pass; a teardown-heavy `test_gui.py` slice + the former crash-point test pass with no hang/crash. **Could not** verify the CI-only native crash locally (no deterministic repro on this platform) — real confirmation is repeated green e2e runs on windows/3.14, and #94's breadcrumb would name any recurrence.

## Review

An independent clean-context review ran on the diff. It caught that an earlier **bounded** 10s job-thread wait re-introduced the crash (timeout → discarded `False` → `accept()` → destroy-while-running); fixed by switching to unbounded waits (above). Two other suggestions were rejected with reasons: `terminate()` on timeout (unsafe) and restoring `sys.stdout` on shutdown (`sys.__stdout__` is `None` in the frozen no-console GUI, so it would make later `print()` crash).

## Notes
- No serialized-format or public-API changes. HISTORY.rst updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)