### PR TITLE
CI: retry bio-tool downloads to survive transient SSL blips

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -121,6 +121,18 @@ jobs:
                     key: bio-tools-${{ runner.os }}-kallisto0.51.1-bowtie2v2.5.1
             -   name: Install kallisto
                 run: |
+                    # Retry downloads: wget treats a transient "Unable to establish SSL connection"
+                    # to GitHub's release-asset CDN as fatal and won't retry it on its own, so a single
+                    # network blip on a cache miss would otherwise fail the whole job. Re-invoke wget.
+                    dl() {
+                        for attempt in 1 2 3 4 5; do
+                            wget --tries=3 --timeout=30 --continue "$1" && return 0
+                            echo "::warning::download failed (attempt ${attempt}/5): $1 - retrying in 15s"
+                            sleep 15
+                        done
+                        echo "::error::download failed after 5 attempts: $1"
+                        return 1
+                    }
                     # macOS needs the hdf5 runtime whether or not the binary was restored from cache.
                     if [ "$RUNNER_OS" == "macOS" ]; then
                          brew install hdf5
@@ -130,12 +142,12 @@ jobs:
                     # Download only on a cache miss; the extracted 'kallisto' dir is restored otherwise.
                     if [ ! -d "${GITHUB_WORKSPACE}/kallisto" ]; then
                          if [ "$RUNNER_OS" == "Linux" ]; then
-                              wget  https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_linux-v0.51.1.tar.gz
+                              dl https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_linux-v0.51.1.tar.gz
                          elif [ "$RUNNER_OS" == "macOS" ]; then
-                              wget  https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_mac_m1-v0.51.1.tar.gz
+                              dl https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_mac_m1-v0.51.1.tar.gz
                          elif [ "$RUNNER_OS" == "Windows" ]; then
                               choco install wget -y
-                              wget  https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_windows-v0.51.1.tar.gz
+                              dl https://github.com/pachterlab/kallisto/releases/download/v0.51.1/kallisto_windows-v0.51.1.tar.gz
                          else
                               echo "$RUNNER_OS not supported"
                               exit 1
@@ -149,11 +161,23 @@ jobs:
                 run: kallisto version
             -   name: Install bowtie2
                 run: |
+                    # Retry downloads for the same reason as the kallisto step: a transient SSL blip to
+                    # GitHub's release-asset CDN is fatal to wget and, without a retry, fails the job
+                    # before any test runs (this step, unlike kallisto, has no continue-on-error).
+                    dl() {
+                        for attempt in 1 2 3 4 5; do
+                            wget --tries=3 --timeout=30 --continue "$1" && return 0
+                            echo "::warning::download failed (attempt ${attempt}/5): $1 - retrying in 15s"
+                            sleep 15
+                        done
+                        echo "::error::download failed after 5 attempts: $1"
+                        return 1
+                    }
                     if [ "$RUNNER_OS" == "Windows" ]; then
                          # Download only on a cache miss; the extracted dir is restored otherwise.
                          if [ ! -d "${GITHUB_WORKSPACE}/bowtie2-2.5.1-mingw-x86_64" ]; then
                               choco install wget -y
-                              wget  https://github.com/BenLangmead/bowtie2/releases/download/v2.5.1/bowtie2-2.5.1-mingw-x86_64.zip
+                              dl https://github.com/BenLangmead/bowtie2/releases/download/v2.5.1/bowtie2-2.5.1-mingw-x86_64.zip
                               7z x bowtie2-2.5.1-mingw-x86_64.zip
                          fi
                          echo "${GITHUB_WORKSPACE}/bowtie2-2.5.1-mingw-x86_64" >> $GITHUB_PATH


### PR DESCRIPTION
## What & why

On PR #95's CI, the **windows-latest / 3.13** job failed at the **Install bowtie2** setup step — before a single test ran:

```
wget .../bowtie2-2.5.1-mingw-x86_64.zip
Resolving release-assets.githubusercontent.com ... 185.199.108.133, ...
Unable to establish SSL connection.
##[error]Process completed with exit code 4.
```

A transient TLS handshake failure to GitHub's release-asset CDN on a **cache miss**. `wget` treats an SSL handshake failure as **fatal** and does not retry it (its default `--tries=20` only covers timeouts / refused connections), so one blip kills the whole job. The bowtie2 step — unlike kallisto — has no `continue-on-error`, so it fails hard.

This is unrelated to any code change; it's pure CI flakiness. (A re-run would likely have passed.)

## Fix

Wrap the kallisto **and** bowtie2 downloads in a small `dl()` retry loop that **re-invokes `wget`** (5 attempts, 15 s apart, `--continue` to resume partials, `--timeout=30`). Re-invoking is the key: it recovers from the fatal-SSL case that `wget`'s own `--tries` won't.

Verified locally:
- YAML parses; both steps still wired correctly (kallisto keeps `continue-on-error: true`, bowtie2 unchanged).
- Under `bash -eo pipefail` (how GitHub runs `shell: bash`, Git Bash on Windows included): a transient failure retries then proceeds; an **exhausted** retry returns 1 and the bare `dl <url>` call cleanly **fails the step** (confirmed the `set -e` propagation with a minimal repro).
- No behaviour change on a cache hit — the `if [ ! -d ... ]` guard skips downloads entirely.

## Notes
- CI-only change; no `HISTORY.rst` entry (not user-facing).
- The `dl()` helper is duplicated across the two steps because GitHub steps run in separate shells and can't share a function; a 7-line helper inline is simpler than a shared script file with cross-platform exec concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)