### PR TITLE
CI: keep Actions cache under the 10 GB cap

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -9,6 +9,22 @@ on:
             - '**/*.rst'
             - 'docs/**'
             - '.claude/**'
+    # Warm the Actions cache on the long-lived integration branch. GitHub scopes caches by ref and
+    # only lets a run restore caches created in (a) its own ref, (b) its base branch, or (c) the
+    # default branch -- NEVER a sibling PR's ref. So without a run on `development`, every PR starts
+    # cold and writes its own ~5 GB copy of the heavy OS/tool caches (LLVM, kallisto/bowtie2, uv
+    # wheels) into its own ref scope; a handful of open PRs then blows past the 10 GB repo cap and
+    # thrashes (evict -> re-download -> re-save). Running here seeds those caches on `development`
+    # so every PR branched off it restores them instead of rebuilding. The test tiers are skipped
+    # on push (see the `github.event_name == 'pull_request'` guards below) -- this run exists only
+    # to populate caches, so it stops after the setup/install steps.
+    push:
+        branches: [ development ]
+        paths-ignore:
+            - '**/*.md'
+            - '**/*.rst'
+            - 'docs/**'
+            - '.claude/**'
 jobs:
     build:
 
@@ -72,7 +88,12 @@ jobs:
                 uses: actions/cache@v5
                 with:
                     path: ${{ runner.temp }}/llvm
-                    key: llvm
+                    # Key must carry the OS and LLVM version. The bare `llvm` key silently restored a
+                    # stale cache on any version bump (the path-derived cache "version" only segregates
+                    # Linux from Windows, not LLVM 14 from a future 15). ~1 GB (Linux) / ~0.7 GB
+                    # (Windows) per copy -- seeded once on `development` (see the `push` trigger) and
+                    # restored by PRs rather than re-downloaded into each PR's own cache scope.
+                    key: llvm-${{ runner.os }}-14.0
             -   name: Install LLVM and Clang
                 if: runner.os != 'macOS'
                 uses: KyleMayes/install-llvm-action@v2
@@ -195,6 +216,8 @@ jobs:
             # in `coverage run` (see RUN_TESTS above); every other job invokes pytest directly. Tiers
             # are assigned automatically in tests/conftest.py; see pytest.ini for definitions.
             -   name: Unit tests
+                # Skipped on the `development` cache-warming push; runs only for PRs (see `on:` above).
+                if: github.event_name == 'pull_request'
                 run: ${{ env.RUN_TESTS }} -m unit --durations=25 tests/
             # The network/web-API tests just hit external services (UniProt/Ensembl/PANTHER/
             # PhylomeDB/KEGG/GO), so their results are platform-independent and running them on all 9
@@ -204,11 +227,13 @@ jobs:
             # no loss of coverage. On the other 8 cells this step is skipped; integration_tools/e2e
             # still run (a skipped step keeps success() true, so it doesn't fail the job).
             -   name: Integration tests (network / web APIs)
-                if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+                if: ${{ github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }}
                 run: ${{ env.RUN_TESTS }} -m integration_net --durations=25 tests/
             -   name: Integration tests (R / CLI tools)
+                if: github.event_name == 'pull_request'
                 run: ${{ env.RUN_TESTS }} -m integration_tools --durations=25 tests/
             -   name: End-to-end (GUI) tests
+                if: github.event_name == 'pull_request'
                 run: ${{ env.RUN_TESTS }} -m e2e --durations=25 tests/
             -   name: Report last test before a crash
                 # Runs whenever a prior tier failed (incl. a native crash that produced no pytest
@@ -230,11 +255,11 @@ jobs:
                 timeout-minutes: 15
                 uses: mxschmitt/action-tmate@v3
             -   name: Generate lcov file
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
                 run: coverage lcov
             -   name: Coveralls Parallel
                 uses: coverallsapp/github-action@v2
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
                 continue-on-error: true
                 with:
                     flag-name: run-${{ join(matrix.*, '-') }}
@@ -243,7 +268,9 @@ jobs:
 
     finish:
         name: Finish submitting coverage
-        if: ${{ always() }}
+        # Only PRs collect coverage; the `development` cache-warming push submits nothing, so there is
+        # no parallel run to finalize.
+        if: ${{ always() && github.event_name == 'pull_request' }}
         needs: build
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/cleanup_pr_caches.yml
+++ b/.github/workflows/cleanup_pr_caches.yml
@@ -1,0 +1,38 @@
+name: Cleanup PR caches
+
+# When a PR closes (merged or not), delete the Actions caches scoped to its ref. Those caches live
+# under refs/pull/<n>/merge and, by GitHub's scoping rules, can only ever be restored by that same
+# PR -- never by a sibling PR or by `development`. Once the PR is closed they are pure dead weight:
+# unreachable to everything, yet still counted against the repo's 10 GB cache cap, where they evict
+# (LRU) caches that open PRs could actually use. Reaping them here keeps the shared budget for the
+# seeded `development` caches (see build_ci.yml's `push` trigger) plus in-flight PRs.
+on:
+    pull_request:
+        types: [ closed ]
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        permissions:
+            # Required to delete caches via the Actions cache API.
+            actions: write
+            contents: read
+        steps:
+            -   name: Delete caches for the closed PR
+                # `set +e` so a mid-loop failure (e.g. a cache already evicted) doesn't fail the job.
+                # For PRs opened from forks the pull_request token is read-only, so deletion is a no-op
+                # there; that's fine -- this repo's PRs come from same-repo branches.
+                run: |
+                    gh extension install actions/gh-actions-cache
+                    echo "Fetching cache keys for $BRANCH"
+                    cacheKeys=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1)
+                    set +e
+                    for cacheKey in $cacheKeys; do
+                        echo "Deleting $cacheKey"
+                        gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+                    done
+                    echo "Done"
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    REPO: ${{ github.repository }}
+                    BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
## Problem

The repo's Actions cache kept exceeding GitHub's **10 GB** cap and thrashing (evict → re-download → re-save every run). Audit of the live caches (`gh cache list`) showed **12.2 GB across 33 caches**, every one scoped to a `refs/pull/*/merge` ref, with **nothing on `development`**.

Root cause is GitHub's cache scoping: a run can only restore caches from **its own ref, its base branch, or the default branch — never a sibling PR**. Because CI only ran on `pull_request`, `development` was never seeded, so every PR started cold and wrote its own full copy of the heavy repo-independent caches into its own ref scope:

| Cache | Per PR ref |
|---|---|
| LLVM (Linux ~1.15 GB + Windows ~0.7 GB) | ~1.85 GB |
| uv wheels (9 matrix cells) | ~3.2 GB |
| kallisto/bowtie2 | ~0.05 GB |

A fully-populated ref ≈ **5 GB**, so just **2 concurrent PRs** already blew the budget. (Observed: closed PRs #55 and #95 alone were holding 9.2 GB of caches no other run could even read.)

## Fixes

**1. Seed caches on `development` (the default branch + base of ~all PRs).** `build_ci.yml` now also runs on `push:` to `development`, but the test tiers, coverage, and the `finish` job are gated behind `github.event_name == 'pull_request'`. So the push runs only the setup/install steps and populates the caches; it does **not** run the ~49-min suite. Since it's the **same workflow** computing the keys on both push and PR runs, the keys are byte-identical → PRs restore the seeded entries instead of rebuilding. `development` being the default branch means *every* PR (any base) can read them.

**2. Reap a PR's caches when it closes** (new `cleanup_pr_caches.yml`). Once a PR closes, its ref-scoped caches are unreachable to every other run yet still count against the 10 GB cap and evict caches open PRs need. GitHub's canonical `pull_request: closed` → `gh actions-cache delete` pattern.

**3. Version the LLVM cache key** (`llvm` → `llvm-${{ runner.os }}-14.0`). The bare key would silently restore a stale LLVM on any version bump; versioning also makes the seeded-on-`development` copy match cleanly per-OS.

## Expected steady state

`development` holds ~one shared ~5 GB set; PRs with unchanged deps restore it and write **~0**; only PRs that change `requirements*.txt`/`pyproject.toml` write their own (bounded) uv caches. Comfortably under 10 GB regardless of open-PR count. The very first beneficiary is the next PR after this merges — merging this into `development` triggers the first warm run.

## Verifying it works (after merge)

- `gh cache list` should show new caches on `refs/heads/development`.
- The next PR's "Cache LLVM" / setup-uv / bio-tools steps should log **cache hit / restored** rather than re-downloading.

## Not in this PR

- The **`.r-libs` cache is never populated** (separate bug — packages install outside the cached path). Tracked in #113.
- Optional further LLVM shrink: restrict the install to the Python 3.14 cells (the only ones lacking `llvmlite` wheels). Needs a CI run to confirm 3.12/3.13 don't need it, so left out here.

## Test notes

Workflow YAML validated locally (parses; triggers/guards/keys assert as intended). The end-to-end cache hit/miss behavior can only be confirmed on GitHub after merge (needs a real `development` push + a subsequent PR run) — called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
