### PR TITLE
docs: correct pandas->polars return types in API docstrings (#96)

### DIFF
--- a/rnalysis/enrichment.py
+++ b/rnalysis/enrichment.py
@@ -908,7 +908,7 @@ class FeatureSet(set):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with GO terms as rows/index; \
+        :return: a polars DataFrame with GO terms in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
         .. figure:: /figures/ontology_graph.png
@@ -1035,7 +1035,7 @@ class FeatureSet(set):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated pathway names as rows/index; \
+        :return: a polars DataFrame with the indicated pathway names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
 
@@ -1153,7 +1153,7 @@ class FeatureSet(set):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated attribute names as rows/index; \
+        :return: a polars DataFrame with the indicated attribute names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
         .. figure:: /figures/plot_enrichment_results.png
@@ -1238,7 +1238,7 @@ class FeatureSet(set):
         :type return_fig: bool (default=False)
         :param return_fig: if True, returns a matplotlib Figure object in addition to the results DataFrame.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated attribute names as rows/index; \
+        :return: a polars DataFrame with the indicated attribute names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
 
@@ -1317,8 +1317,8 @@ class FeatureSet(set):
         :param long_format:if True, returns a short-form DataFrame, which states the biotypes \
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
-        :rtype: pandas.DataFrame
-        :returns: a pandas DataFrame showing the number of values belonging to each biotype, \
+        :rtype: polars.DataFrame
+        :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
         """
         filter_obj = self._convert_to_filter_obj()
@@ -1556,7 +1556,7 @@ class RankedSet(FeatureSet):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated attribute names as rows/index; \
+        :return: a polars DataFrame with the indicated attribute names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
         .. figure:: /figures/ontology_graph_singlelist.png
@@ -1691,7 +1691,7 @@ class RankedSet(FeatureSet):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated attribute names as rows/index; \
+        :return: a polars DataFrame with the indicated attribute names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
         .. figure:: /figures/pathway_graph_singlelist.png
@@ -1801,7 +1801,7 @@ class RankedSet(FeatureSet):
         In most cases parallel processing will lead to shorter computation time, but does not affect the results of \
         the analysis otherwise.
         :rtype: pl.DataFrame (default) or Tuple[pl.DataFrame, matplotlib.figure.Figure]
-        :return: a pandas DataFrame with the indicated attribute names as rows/index; \
+        :return: a polars DataFrame with the indicated attribute names in the first column; \
         and a matplotlib Figure, if 'return_figure' is set to True.
 
         .. figure:: /figures/plot_enrichment_results_single_set.png

--- a/rnalysis/enrichment.py
+++ b/rnalysis/enrichment.py
@@ -1317,7 +1317,7 @@ class FeatureSet(set):
         :param long_format:if True, returns a short-form DataFrame, which states the biotypes \
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
         :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
         """

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -55,7 +55,7 @@ class Filter:
 
     **Attributes**
 
-    df: pandas DataFrame
+    df: polars DataFrame
         A DataFrame that contains the DESeq output file contents. \
         The DataFrame is modified upon usage of filter operations.
     shape: tuple (rows, columns)
@@ -71,7 +71,7 @@ class Filter:
     index_string: string
         A string of all feature indices in the current DataFrame separated by newline.
     """
-    __slots__ = {'fname': 'filename with full path', 'df': 'pandas.DataFrame with the data'}
+    __slots__ = {'fname': 'filename with full path', 'df': 'polars.DataFrame with the data'}
 
     def __init__(self, fname: Union[str, Path], drop_columns: Union[str, List[str]] = None,
                  suppress_warnings: bool = False):
@@ -294,7 +294,7 @@ class Filter:
     def head(self, n: PositiveInt = 5) -> pl.DataFrame:
 
         """
-        Return the first n rows of the Filter object. See pandas.DataFrame.head documentation.
+        Return the first n rows of the Filter object. See polars.DataFrame.head documentation.
 
         :type n: positive int, default 5
         :param n: Number of rows to show.
@@ -329,11 +329,11 @@ class Filter:
     def tail(self, n: PositiveInt = 5) -> pl.DataFrame:
 
         """
-        Return the last n rows of the Filter object. See pandas.DataFrame.tail documentation.
+        Return the last n rows of the Filter object. See polars.DataFrame.tail documentation.
 
         :type n: positive int, default 5
         :param n: Number of rows to show.
-        :rtype: pandas.DataFrame
+        :rtype: polars.DataFrame
         :return: returns the last n rows of the Filter object.
 
 
@@ -1391,14 +1391,14 @@ class Filter:
         """
         Generate descriptive statistics that summarize the central tendency, dispersion and shape \
         of the dataset's distribution, excluding NaN values. \
-        For more information see the documentation of pandas.DataFrame.describe.
+        For more information see the documentation of polars.DataFrame.describe.
 
         :type percentiles: list-like of floats (default=(0.01, 0.25, 0.5, 0.75, 0.99))
         :param percentiles: The percentiles to include in the output. \
         All should fall between 0 and 1. \
         The default is [.25, .5, .75], which returns the 25th, 50th, and 75th percentiles.
         :return: Summary statistics of the dataset.
-        :rtype: Series or DataFrame
+        :rtype: polars.DataFrame
 
 
         :Examples:
@@ -1575,8 +1575,8 @@ class Filter:
         :param long_format:if True, returns a short-form DataFrame, which states the biotypes \
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
-        :rtype: pandas.DataFrame
-        :returns: a pandas DataFrame showing the number of values belonging to each biotype, \
+        :rtype: polars.DataFrame
+        :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
         """
         # load the Biotype Reference Table
@@ -1619,8 +1619,8 @@ class Filter:
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
         :param ref: Name of the biotype reference table used to determine biotype. Default is ce11 (included in the package).
-        :rtype: pandas.DataFrame
-        :returns: a pandas DataFrame showing the number of values belonging to each biotype, \
+        :rtype: polars.DataFrame
+        :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
 
 
@@ -2270,9 +2270,9 @@ class FoldChangeFilter(Filter):
 
     **Attributes**
 
-    df: pandas Series
-        A Series that contains the fold change values. \
-        The Series is modified upon usage of filter operations.
+    df: polars DataFrame
+        A DataFrame containing the gene names and their fold change values. \
+        The DataFrame is modified upon usage of filter operations.
     shape: tuple (rows, columns)
         The dimensions of df.
     columns: list
@@ -2371,7 +2371,7 @@ class FoldChangeFilter(Filter):
         :type random_seed: The random seed used to initialize the pseudorandom generator for the randomization test. \
         By default it is picked at random, but you can set it to a particular integer to get consistents results \
         over multiple runs.
-        :rtype: pandas DataFrame
+        :rtype: polars.DataFrame
         :return: A Dataframe with the number of given genes, the observed fold change for the given group of genes, \
         the expected fold change for a group of genes of that size and the p value for the comparison.
 
@@ -2562,7 +2562,7 @@ class DESeqFilter(Filter):
 
     **Attributes**
 
-    df: pandas DataFrame
+    df: polars DataFrame
         A DataFrame that contains the DESeq output file contents. \
         The DataFrame is modified upon usage of filter operations.
     shape: tuple (rows, columns)
@@ -2939,7 +2939,7 @@ class CountFilter(Filter):
 
     **Attributes**
 
-    df: pandas DataFrame
+    df: polars DataFrame
         A DataFrame that contains the count matrix contents. \
         The DataFrame is modified upon usage of filter operations.
     shape: tuple (rows, columns)
@@ -3615,7 +3615,7 @@ class CountFilter(Filter):
         [['SAMPLE1A', 'SAMPLE1B', 'SAMPLE1C'], ['SAMPLE2A', 'SAMPLE2B', 'SAMPLE2C'],'SAMPLE3' , 'SAMPLE6'] \
         and the resulting output will be a DataFrame containing the following columns: \
         ['SAMPLE1', 'SAMPLE2', 'SAMPLE3', 'SAMPLE6']
-        :return: a pandas DataFrame containing samples/averaged subsamples according to the specified sample_list.
+        :return: a polars DataFrame containing samples/averaged subsamples according to the specified sample_list.
 
         """
         assert isinstance(function, str), "'function' must be a string!"

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -333,7 +333,7 @@ class Filter:
 
         :type n: positive int, default 5
         :param n: Number of rows to show.
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
         :return: returns the last n rows of the Filter object.
 
 
@@ -1398,7 +1398,7 @@ class Filter:
         All should fall between 0 and 1. \
         The default is [.25, .5, .75], which returns the 25th, 50th, and 75th percentiles.
         :return: Summary statistics of the dataset.
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
 
 
         :Examples:
@@ -1575,7 +1575,7 @@ class Filter:
         :param long_format:if True, returns a short-form DataFrame, which states the biotypes \
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
         :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
         """
@@ -1619,7 +1619,7 @@ class Filter:
         in the Filter object and their count. Otherwise, returns a long-form DataFrame,
         which also provides descriptive statistics of each column per biotype.
         :param ref: Name of the biotype reference table used to determine biotype. Default is ce11 (included in the package).
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
         :returns: a polars DataFrame showing the number of values belonging to each biotype, \
         as well as additional descriptive statistics of format=='long'.
 
@@ -2371,7 +2371,7 @@ class FoldChangeFilter(Filter):
         :type random_seed: The random seed used to initialize the pseudorandom generator for the randomization test. \
         By default it is picked at random, but you can set it to a particular integer to get consistents results \
         over multiple runs.
-        :rtype: polars.DataFrame
+        :rtype: pl.DataFrame
         :return: A Dataframe with the number of given genes, the observed fold change for the given group of genes, \
         the expected fold change for a group of genes of that size and the p value for the comparison.
 

--- a/rnalysis/general.py
+++ b/rnalysis/general.py
@@ -148,8 +148,8 @@ def print_settings_file():
 
 def save_to_csv(df: Union[pl.DataFrame, Filter], filename: str):
     """
-    save a pandas DataFrame or Filter object to csv.
-    :type df: Filter object or pandas DataFrame
+    save a polars DataFrame or Filter object to csv.
+    :type df: Filter object or polars DataFrame
     :param df: object to be saved
     :type filename: str
     :param filename: name for the saved file. Specify full path to control the directory where the file will be saved.


### PR DESCRIPTION
Fixes the docstring half of #96.

## What
Since the 4.0 Polars migration the public API returns **Polars** objects, but many docstrings in `filtering`/`enrichment`/`general` still described **pandas** return types. Because docstrings are rendered both in the generated API docs and in the in-app help (API→GUI reflection contract), users were told they get a pandas object (with an index) when they actually get a Polars one.

This corrects the **type wording only**:
- `:rtype:` lines → `pl.DataFrame` (matching the code's `import polars as pl` alias and the existing enrichment `:rtype:` lines).
- `:return:` / `:returns:` prose → "a polars DataFrame …", and the misleading "as rows/index" phrasing → "in the first column" (Polars frames have no index).
- `df:` attribute docs → "polars DataFrame" (and `FoldChangeFilter.df`, previously mislabelled "pandas Series", is now correctly "polars DataFrame" — a two-column gene/fold-change frame).
- "See pandas.DataFrame.head/tail/describe" references → their polars equivalents.

## Verification
Each edited function's return type was confirmed empirically in a real `rnalysis` env (Polars 1.41.2), not assumed — e.g. `head`/`tail`/`describe`/`biotypes_*`, every enrichment function, and `FoldChangeFilter.df`/`randomization_test` all genuinely return Polars. Legitimate internal pandas usage (`to_pandas()`, `pl.from_pandas()`, `import pandas`) is left untouched. Files compile and import cleanly.

## Review
Passed a clean-context two-axis review (Standards + Spec). The only actionable note — mixed `polars.DataFrame` / `pl.DataFrame` spelling — is addressed in the second commit (standardized on `pl.DataFrame`).

## Scope / follow-up
Deliberately **type-wording only**. Regenerating the `:Examples:` REPL output blocks (which still show pandas repr) is intentionally deferred to #110, together with the same fix in the hand-written user guides — I have the real Polars outputs captured and will handle them there (ideally with a doctest check so they can't drift again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
