### PR TITLE
Harden import-time legal-value fetchers (guards + request timeouts)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Fixed
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
 * Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.
 * Fixed a bug where closing the RNAlysis window could occasionally crash the application, because its background worker and console threads were signalled to stop but not waited for before the window was destroyed. Closing now shuts those threads down cleanly first.
+* Fixed a bug where a malformed or slow response from an external service (PantherDB, UniProt, Ensembl, or PhylomeDB) while loading the lists of supported organisms and gene-ID types could crash RNAlysis on startup or make it hang. These lookups now use a request timeout and degrade gracefully to an empty list with a warning instead.
 
 
 4.2.0 (2026-05-30)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ Fixed
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
 * Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.
 * Fixed a bug where closing the RNAlysis window could occasionally crash the application, because its background worker and console threads were signalled to stop but not waited for before the window was destroyed. Closing now shuts those threads down cleanly first.
-* Fixed a bug where a malformed or slow response from an external service (PantherDB, UniProt, Ensembl, or PhylomeDB) while loading the lists of supported organisms and gene-ID types could crash RNAlysis on startup or make it hang. These lookups now use a request timeout and degrade gracefully to an empty list with a warning instead.
+* Fixed a bug where a malformed or unreachable external service (PantherDB, UniProt, Ensembl, or PhylomeDB) could crash RNAlysis on startup while it loaded the lists of supported organisms and gene-ID types. These lookups now degrade gracefully to an empty list with a warning, and their network requests use timeouts so a stalled service can't freeze startup.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -2243,10 +2243,15 @@ def find_best_gene_mapping(ids: Tuple[str, ...], map_from_options: Union[Tuple[s
     return parsed_results[sorted_keys[0]]
 
 
+# Connect/read timeout (seconds) for the small "legal values" metadata fetches below. These run at
+# import time to populate GUI dropdowns / type annotations, so a hung request would freeze startup.
+LEGAL_VALUES_REQUEST_TIMEOUT = (10, 30)
+
+
 @functools.lru_cache(maxsize=2)
 def get_legal_panther_taxons():
     URL = 'https://www.pantherdb.org/services/oai/pantherdb/supportedgenomes'
-    req = requests.post(URL)
+    req = requests.post(URL, timeout=LEGAL_VALUES_REQUEST_TIMEOUT)
     req.raise_for_status()
     genomes = req.json()['search']['output']['genomes']['genome']
     # PantherDB returns a single genome dict (not a list) when only one genome is present; normalize
@@ -2288,7 +2293,7 @@ def get_legal_gene_id_types():
     abbrev_dict_to = {}
     abbrev_dict_from = {}
 
-    req = requests.get(URL)
+    req = requests.get(URL, timeout=LEGAL_VALUES_REQUEST_TIMEOUT)
     req.raise_for_status()
     entries = json.loads(req.text)['groups']
     entries_filtered = []

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -1263,6 +1263,10 @@ def translate_mappings(ids: list, translated_ids: list, mapping_one2one: dict,
 
 class PhylomeDBOrthologMapper:
     URL = 'ftp.phylomedb.org'
+    # Socket timeout (seconds) for the FTP control + data connections. get_legal_species() runs at
+    # import time (it populates a Literal[...] annotation), so without a timeout a stalled FTP server
+    # would freeze `import rnalysis.filtering` indefinitely.
+    FTP_TIMEOUT = 30
 
     def __init__(self, map_to_organism, map_from_organism='auto', gene_id_type='auto'):
         legal_species = self.get_legal_species()
@@ -1420,7 +1424,7 @@ class PhylomeDBOrthologMapper:
 
     @staticmethod
     def _connect():
-        ftp = ftplib.FTP(PhylomeDBOrthologMapper.URL)
+        ftp = ftplib.FTP(PhylomeDBOrthologMapper.URL, timeout=PhylomeDBOrthologMapper.FTP_TIMEOUT)
         ftp.login()
         ftp.cwd('/metaphors/latest')
         return ftp

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -85,6 +85,9 @@ def type_to_supertype(this_type):
 # plus a warning instead. RequestException covers connection/HTTP/timeout failures (the underlying
 # io.get_legal_* calls now pass a request timeout); ValueError covers JSON-decode errors from a
 # 200-with-garbage body; Key/Type/Index errors cover otherwise-parseable-but-unexpected shapes.
+# These getters are lru_cached, so a degraded empty result is intentionally pinned for the process:
+# the Literal[...] annotations are evaluated exactly once at import, and the warning tells the user to
+# restart RNAlysis to retry.
 _LEGAL_VALUE_FETCH_ERRORS = (requests.exceptions.RequestException, tenacity.RetryError,
                              ValueError, KeyError, TypeError, IndexError)
 

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -79,11 +79,21 @@ def type_to_supertype(this_type):
     return this_type
 
 
+# Errors that mean "couldn't fetch or parse the remote list of legal values". These getters run at
+# import time to populate Literal[...] type annotations, so an uncaught error here crashes
+# `import rnalysis.filtering` for every user and every test-collection run — degrade to an empty tuple
+# plus a warning instead. RequestException covers connection/HTTP/timeout failures (the underlying
+# io.get_legal_* calls now pass a request timeout); ValueError covers JSON-decode errors from a
+# 200-with-garbage body; Key/Type/Index errors cover otherwise-parseable-but-unexpected shapes.
+_LEGAL_VALUE_FETCH_ERRORS = (requests.exceptions.RequestException, tenacity.RetryError,
+                             ValueError, KeyError, TypeError, IndexError)
+
+
 @functools.lru_cache(maxsize=2)
 def get_gene_id_types() -> typing.Tuple[str, ...]:
     try:
         gene_id_types = parsing.data_to_tuple(io.get_legal_gene_id_types()[0].keys())
-    except requests.exceptions.ConnectionError:
+    except _LEGAL_VALUE_FETCH_ERRORS:
         gene_id_types = tuple()
         warnings.warn('Failed to retrieve gene ID mapping data from UniProtKB. '
                       'Some features may not work as intended. '
@@ -96,10 +106,7 @@ def get_gene_id_types() -> typing.Tuple[str, ...]:
 def get_panther_taxons() -> typing.Tuple[str, ...]:
     try:
         taxons = io.get_legal_panther_taxons()
-    except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError,
-            KeyError, ValueError, TypeError):
-        # Also swallow parse errors: once PantherDB answers 200 (over https) but in an unexpected
-        # shape, json/key/type errors would otherwise crash instead of degrading gracefully.
+    except _LEGAL_VALUE_FETCH_ERRORS:
         taxons = tuple()
         warnings.warn('Failed to retrieve legal taxons from PantherDB. '
                       'Some features may not work as intended. '
@@ -112,7 +119,7 @@ def get_panther_taxons() -> typing.Tuple[str, ...]:
 def get_phylomedb_taxons() -> typing.Tuple[str, ...]:
     try:
         taxons = io.get_legal_phylomedb_taxons()
-    except ftplib.all_errors:
+    except (*_LEGAL_VALUE_FETCH_ERRORS, *ftplib.all_errors):
         taxons = tuple()
         warnings.warn('Failed to retrieve legal taxons from PhylomeDB. '
                       'Some features may not work as intended. '
@@ -125,7 +132,7 @@ def get_phylomedb_taxons() -> typing.Tuple[str, ...]:
 def get_ensembl_taxons() -> typing.Tuple[str, ...]:
     try:
         taxons = parsing.data_to_tuple(io.get_legal_ensembl_taxons())
-    except (requests.exceptions.ConnectionError, tenacity.RetryError):
+    except _LEGAL_VALUE_FETCH_ERRORS:
         taxons = tuple()
         warnings.warn('Failed to retrieve legal taxons from Ensembl. '
                       'Some features may not work as intended. '

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1921,3 +1921,53 @@ def test_get_legal_panther_taxons_handles_list_and_single(monkeypatch, genome_no
         assert io.get_legal_panther_taxons() == expected
     finally:
         io.get_legal_panther_taxons.cache_clear()
+
+
+def test_get_legal_panther_taxons_passes_request_timeout(monkeypatch):
+    # A bare requests.post with no timeout can hang forever; this runs at import time, so a hang
+    # freezes app startup. Ensure a request timeout is always passed.
+    captured = {}
+
+    class _FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {'search': {'output': {'genomes': {'genome': [{'long_name': 'Homo sapiens'}]}}}}
+
+    def _fake_post(*args, **kwargs):
+        captured['timeout'] = kwargs.get('timeout')
+        return _FakeResp()
+
+    monkeypatch.setattr(io.requests, 'post', _fake_post)
+    io.get_legal_panther_taxons.cache_clear()
+    try:
+        io.get_legal_panther_taxons()
+    finally:
+        io.get_legal_panther_taxons.cache_clear()
+    assert captured['timeout'] is not None
+
+
+def test_get_legal_gene_id_types_passes_request_timeout(monkeypatch):
+    captured = {}
+    payload_text = ('{"groups": [{"groupName": "UniProt", "items": '
+                    '[{"displayName": "UniProtKB AC/ID", "name": "UniProtKB_AC-ID", '
+                    '"from": true, "to": false}]}]}')
+
+    class _FakeResp:
+        text = payload_text
+
+        def raise_for_status(self):
+            pass
+
+    def _fake_get(*args, **kwargs):
+        captured['timeout'] = kwargs.get('timeout')
+        return _FakeResp()
+
+    monkeypatch.setattr(io.requests, 'get', _fake_get)
+    io.get_legal_gene_id_types.cache_clear()
+    try:
+        io.get_legal_gene_id_types()
+    finally:
+        io.get_legal_gene_id_types.cache_clear()
+    assert captured['timeout'] is not None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1923,6 +1923,7 @@ def test_get_legal_panther_taxons_handles_list_and_single(monkeypatch, genome_no
         io.get_legal_panther_taxons.cache_clear()
 
 
+@pytest.mark.unit  # fully mocked; opt out of the module's default integration_net tier
 def test_get_legal_panther_taxons_passes_request_timeout(monkeypatch):
     # A bare requests.post with no timeout can hang forever; this runs at import time, so a hang
     # freezes app startup. Ensure a request timeout is always passed.
@@ -1945,9 +1946,10 @@ def test_get_legal_panther_taxons_passes_request_timeout(monkeypatch):
         io.get_legal_panther_taxons()
     finally:
         io.get_legal_panther_taxons.cache_clear()
-    assert captured['timeout'] is not None
+    assert captured['timeout'] == io.LEGAL_VALUES_REQUEST_TIMEOUT
 
 
+@pytest.mark.unit  # fully mocked; opt out of the module's default integration_net tier
 def test_get_legal_gene_id_types_passes_request_timeout(monkeypatch):
     captured = {}
     payload_text = ('{"groups": [{"groupName": "UniProt", "items": '
@@ -1970,4 +1972,4 @@ def test_get_legal_gene_id_types_passes_request_timeout(monkeypatch):
         io.get_legal_gene_id_types()
     finally:
         io.get_legal_gene_id_types.cache_clear()
-    assert captured['timeout'] is not None
+    assert captured['timeout'] == io.LEGAL_VALUES_REQUEST_TIMEOUT

--- a/tests/test_param_typing.py
+++ b/tests/test_param_typing.py
@@ -1,3 +1,7 @@
+import pytest
+import requests
+
+from rnalysis.utils import param_typing
 from rnalysis.utils.param_typing import DEFAULT_ORGANISMS
 
 
@@ -6,3 +10,36 @@ def test_default_organisms_are_spelled_correctly():
     # the match. Guard the historically-misspelled entry in particular.
     assert 'Arabidopsis thaliana' in DEFAULT_ORGANISMS
     assert 'Arabodopsis thaliana' not in DEFAULT_ORGANISMS
+
+
+# The get_*_taxons / get_gene_id_types helpers run at import time (they populate Literal[...] type
+# annotations on Filter/FeatureSet methods), so any uncaught error crashes `import rnalysis.filtering`
+# for every user and every test collection. They must degrade to an empty tuple + a warning instead.
+# See the flaky CI collection error where a PantherDB 200-with-garbage body raised JSONDecodeError.
+@pytest.mark.parametrize('getter_name,io_func_name', [
+    ('get_gene_id_types', 'get_legal_gene_id_types'),
+    ('get_panther_taxons', 'get_legal_panther_taxons'),
+    ('get_ensembl_taxons', 'get_legal_ensembl_taxons'),
+    ('get_phylomedb_taxons', 'get_legal_phylomedb_taxons'),
+])
+@pytest.mark.parametrize('error', [
+    ValueError('Expecting value: line 1 column 1 (char 0)'),  # json.loads on an empty/garbage 200 body
+    KeyError('search'),                                       # 200 but an unexpected JSON shape
+    requests.exceptions.ConnectionError('no network'),
+    requests.exceptions.HTTPError('500 server error'),
+    requests.exceptions.ReadTimeout('timed out'),            # the request-timeout path added here
+])
+def test_legal_value_getter_degrades_on_bad_response(monkeypatch, getter_name, io_func_name, error):
+    getter = getattr(param_typing, getter_name)
+
+    def _raise(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(param_typing.io, io_func_name, _raise)
+    getter.cache_clear()  # these are lru_cached; force re-evaluation through the mock
+    try:
+        with pytest.warns(UserWarning):
+            result = getter()
+        assert result == tuple()
+    finally:
+        getter.cache_clear()


### PR DESCRIPTION
## Problem

The `get_*_taxons` / `get_gene_id_types` helpers in `param_typing` run **at import time** — they populate `Literal[...]` type annotations on `Filter`/`FeatureSet` methods (e.g. `find_paralogs_panther`). So any uncaught error inside them crashes `import rnalysis.filtering` for **every user at startup** and **every test-collection run**.

A flaky CI collection error ([job](https://github.com/GuyTeichman/RNAlysis/actions/runs/30698595025/job/91365545236)) traced to PantherDB answering **HTTP 200 with an empty/garbage body**: `raise_for_status()` passes, then `json.loads(...)` raises `JSONDecodeError`, which the narrow `except (ConnectionError, HTTPError, ...)` guards didn't catch → 12 identical collection errors.

The PantherDB *parsing* was already hardened on `development` (commit `13d4be0b`), but the sibling fetchers (`get_gene_id_types`, `get_ensembl_taxons`, `get_phylomedb_taxons`) still had narrow guards, and **none** of the bare `requests` calls had a timeout.

## Changes

- **Broaden all four guards** via a shared `_LEGAL_VALUE_FETCH_ERRORS` tuple: `RequestException` (connection/HTTP/**timeout**), `ValueError` (JSON-decode of a 200-with-garbage body), `Key/Type/Index` errors (unexpected-but-parseable shapes), `tenacity.RetryError` (Ensembl), and `ftplib.all_errors` kept for PhylomeDB. All degrade to an empty tuple + warning uniformly.
- **Add request timeouts** (`(10, 30)` connect/read, matching the existing `OrthoInspector` pattern) to the previously-bare `requests.post`/`requests.get` in `io.get_legal_panther_taxons` and `io.get_legal_gene_id_types`, so a hung service can't freeze startup.
  - This is *why* the guards must catch `requests.exceptions.Timeout`: a `ReadTimeout` is neither `ConnectionError` nor `HTTPError` and would otherwise escape even the newly-hardened panther guard.

## Testing (all pass locally)
- `test_param_typing.py`: parametrized degradation across all four getters × {JSON-decode, bad-shape, connection, HTTP, read-timeout} — 20 new cases + existing = **21 passed**.
- `test_io.py`: new timeout-plumbing tests for panther + gene-id-types; existing mocked panther test still green.
- `import rnalysis.filtering` verified to succeed.
- Not run locally: live-network io tier (env has no guaranteed network) — mocked here; CI covers live paths.

Also adds a `HISTORY.rst` (4.2.1 unreleased) entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)