### PR TITLE
Fix Ensembl lookup POST body double-encoding (400 on auto-detection)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Fixed
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
 * Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.
 * Fixed a bug where closing the RNAlysis window could occasionally crash the application, because its background worker and console threads were signalled to stop but not waited for before the window was destroyed. Closing now shuts those threads down cleanly first.
+* Fixed a bug where automatically detecting the organism or gene-ID type from a set of gene IDs (via Ensembl) failed with an ``HTTP 400`` error, because the request body sent to Ensembl was double-encoded. The request is now formatted correctly.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -946,8 +946,10 @@ def _ensembl_lookup_post_request(gene_ids: Tuple[str, ...]) -> Dict[str, Dict[st
     output = {}
     client = EnsemblRestClient()
     for chunk in tqdm(data_chunks, desc='Submitting jobs...', unit='jobs'):
-        data = {"ids": parsing.data_to_list(chunk)}
-        client.queue_action(req_type, endpoint, params=repr(data).replace("'", '"'))
+        # Pass the body as a dict; the client sends it via aiohttp's json= (which serializes it once).
+        # Passing a pre-serialized JSON string here double-encodes it into a quoted literal that
+        # Ensembl rejects with a 400 Bad Request.
+        client.queue_action(req_type, endpoint, params={"ids": parsing.data_to_list(chunk)})
 
     with tqdm('Finding the best-matching species...', total=client.queue.qsize() + 1) as pbar:
         pbar.update()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -500,13 +500,14 @@ def test_ensmbl_lookup_post_request(monkeypatch):
         assert url == 'https://rest.ensembl.org/lookup/id'
         assert kwargs.get('headers') == {"Content-Type": "application/json", "Accept": "application/json"}
 
-        # Get whatever payload was sent (checking both 'json' and 'data' keys for safety)
-        payload = kwargs.get('json') or kwargs.get('data')
-
-        # If the payload is a stringified JSON, parse it back to a dictionary
-        if isinstance(payload, str):
-            payload = json.loads(payload)
-
+        # The body must be handed to aiohttp as a JSON *object* via `json=`, never as a pre-serialized
+        # string. aiohttp re-encodes whatever `json=` receives with json.dumps(), so passing a string
+        # double-encodes it into a quoted JSON literal ("{\"ids\": [...]}") that Ensembl rejects with a
+        # 400 Bad Request. Assert the raw payload is a dict (and nothing was sent via `data=`) so the
+        # double-encoding regression can't come back.
+        assert kwargs.get('data') is None, "POST body must be sent via json=, not data="
+        payload = kwargs.get('json')
+        assert isinstance(payload, dict), f"POST body must be a dict passed via json=, got {type(payload).__name__}"
         assert payload == {'ids': list(ids)}
 
         return AsyncMockResponse(json_output={this_id: {} for this_id in ids})


### PR DESCRIPTION
## Summary

`_ensembl_lookup_post_request` (used by `infer_taxon_from_gene_ids` / `infer_sources_from_gene_ids`, i.e. the **`'auto'`** organism / gene-ID-type detection path) built the POST body as a **pre-serialized JSON string**:

```python
data = {"ids": [...]}
client.queue_action('post', 'lookup/id', params=repr(data).replace("'", '"'))
```

`EnsemblRestClient` then sends that via aiohttp's `json=`, which serializes it a **second** time:

```
correct body (dict → json=):   {"ids": ["a", "b"]}
current body (string → json=): "{\"ids\": [\"a\", \"b\"]}"   ← Ensembl 400s on this
```

So Ensembl receives a JSON *string literal* instead of an object and returns **400 Bad Request**. Introduced in `8c4ba6db` (the `data=`→`json=` change), live on `master` and `development`.

## Fix

Pass the body as a **dict** so aiohttp serializes it exactly once. One-line change in `_ensembl_lookup_post_request`; `EnsemblRestClient` is untouched.

## Why the existing test didn't catch it

`test_ensmbl_lookup_post_request` monkeypatched `aiohttp.ClientSession.post` — **bypassing aiohttp's real `json=` serialization** — and then `json.loads`-ed the string back before asserting, which hid the double-encoding. The test now asserts the payload handed to `json=` is a **dict** (and nothing goes through `data=`), so the regression can't return. Verified red→green.

## Testing

`pytest tests/test_io.py -k "test_ensmbl_lookup_post_request or infer_taxon or infer_sources"` → **9 passed** locally. The live Ensembl integration tests (`integration_net`) I could not run locally (no network in this env), but this restores the correct request body that endpoint expects.

Part of a small series hardening Ensembl usage (see also the response-caching PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)