### PR TITLE
perf: parallelize the Box-Cox power transform in PCA functions (#123)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 Changed
 *******
 * Updated the required ``polars`` version to 1.43.x (from 1.41.x). Analysis results are unchanged; this was verified against the RNAlysis test suite.
+* The Principal Component Analysis functions (``pca``, ``sort_by_principal_component``, and ``split_by_principal_components``) now run substantially faster on large datasets, by parallelizing the per-gene Box-Cox power transform across CPU cores. Results are unchanged up to floating-point precision (verified against the test suite's reference outputs).
 
 Fixed
 ******

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -5219,7 +5219,8 @@ class CountFilter(Filter):
         self._validate_is_normalized()
         suffix = f'_sortbyPC{component}' + 'powertransform' * bool(power_transform)
         data = self.df[self._numeric_columns].to_numpy().transpose()
-        data_standardized = generic.standard_box_cox(data) if power_transform else generic.standardize(data)
+        data_standardized = generic.standard_box_cox(
+            data, parallel_backend=generic.box_cox_parallel_backend()) if power_transform else generic.standardize(data)
         pca_obj = PCA(component)
         pca_obj.fit(data_standardized)
         loading = self.df.select(pl.first()).with_columns(
@@ -5265,7 +5266,8 @@ class CountFilter(Filter):
               f'contributing to each specified Principal Component...')
 
         data = self.df[self._numeric_columns].transpose()
-        data_standardized = generic.standard_box_cox(data) if power_transform else generic.standardize(data)
+        data_standardized = generic.standard_box_cox(
+            data, parallel_backend=generic.box_cox_parallel_backend()) if power_transform else generic.standardize(data)
 
         pca_obj = PCA(n_components)
         pca_obj.fit(data_standardized)
@@ -5341,7 +5343,8 @@ class CountFilter(Filter):
         if samples == 'all':
             samples = [[col] for col in self._numeric_columns]
         data = self.df.select(pl.col(parsing.flatten(samples))).transpose()
-        data_standardized = generic.standard_box_cox(data) if power_transform else generic.standardize(data)
+        data_standardized = generic.standard_box_cox(
+            data, parallel_backend=generic.box_cox_parallel_backend()) if power_transform else generic.standardize(data)
 
         pca_obj = PCA()
         pcomps = pca_obj.fit_transform(data_standardized)

--- a/rnalysis/utils/generic.py
+++ b/rnalysis/utils/generic.py
@@ -23,7 +23,7 @@ from scipy.special import comb
 from sklearn.preprocessing import PowerTransformer, StandardScaler
 from tqdm.auto import tqdm
 
-from rnalysis import __version__
+from rnalysis import FROZEN_ENV, __version__
 
 try:
     import numba
@@ -88,23 +88,70 @@ class ProgressParallel(joblib.Parallel):
         self._pbar.refresh()
 
 
-def standard_box_cox(data: Union[np.ndarray, pl.DataFrame]) -> Union[np.ndarray, pl.DataFrame]:
-    """
+# The Box-Cox power transform fits one lambda per column via a separate optimization. When the data is
+# transposed so that genes are columns (as in the PCA/clustering paths), that is thousands of independent
+# optimizations run in a Python loop, which dominates the runtime of every clustering/PCA call. Splitting the
+# columns across workers is embarrassingly parallel; the result matches the single-process one up to
+# floating-point precision (~1e-15 on the real count-matrix fixture -- transforming a column-slice of a
+# C-contiguous matrix rather than the whole matrix can shift numpy's reduction blocking, far below anything
+# that affects PCA loadings or cluster assignments). Only pay the process-spawn cost when there are enough
+# columns to make it worthwhile.
+BOX_COX_PARALLEL_MIN_COLUMNS = 500
 
-    :param data:
-    :type data:
-    :return:
-    :rtype:
+
+def _box_cox_fit_transform(array: np.ndarray) -> np.ndarray:
+    # sklearn's PowerTransformer(box-cox) fits + applies a separate lambda to each column independently
+    # (and, with the default standardize=True, standardizes each column afterwards).
+    return PowerTransformer(method='box-cox').fit_transform(array + 1)
+
+
+def _parallel_box_cox(array: np.ndarray, backend: str, n_jobs: int) -> np.ndarray:
+    # split the columns into contiguous chunks, Box-Cox each chunk in its own worker, then reassemble in the
+    # original column order. Because every column is transformed independently, this equals the single-process
+    # result exactly.
+    n_columns = array.shape[1]
+    column_chunks = np.array_split(np.arange(n_columns), min(n_jobs, n_columns))
+    transformed_chunks = joblib.Parallel(n_jobs=len(column_chunks), backend=backend)(
+        joblib.delayed(_box_cox_fit_transform)(array[:, chunk]) for chunk in column_chunks)
+    return np.concatenate(transformed_chunks, axis=1)
+
+
+def standard_box_cox(data: Union[np.ndarray, pl.DataFrame],
+                     parallel_backend: str = 'sequential') -> Union[np.ndarray, pl.DataFrame]:
+    """
+    Apply a per-column Box-Cox power transform followed by standardization.
+
+    :param data: the data to transform (columns are transformed independently).
+    :type data: np.ndarray or pl.DataFrame
+    :param parallel_backend: joblib backend used to parallelize the per-column Box-Cox across columns. \
+    The default ('sequential') keeps the original single-process behavior; any other backend parallelizes \
+    once the number of columns reaches ``BOX_COX_PARALLEL_MIN_COLUMNS``. The result is identical either way \
+    up to floating-point precision.
+    :type parallel_backend: str (default='sequential')
     """
     if isinstance(data, pl.DataFrame):
         array = data.select(cs.numeric()).to_numpy()
     else:
         array = data
-    res_array = StandardScaler().fit_transform(PowerTransformer(method='box-cox').fit_transform(array + 1))
+    if parallel_backend not in (None, 'sequential') and array.shape[1] >= BOX_COX_PARALLEL_MIN_COLUMNS:
+        box_cox_array = _parallel_box_cox(array, backend=parallel_backend, n_jobs=joblib.cpu_count())
+    else:
+        box_cox_array = _box_cox_fit_transform(array)
+    res_array = StandardScaler().fit_transform(box_cox_array)
     if isinstance(data, pl.DataFrame):
         return data.select(~cs.numeric()).with_columns(
             pl.DataFrame(res_array, schema=data.select(cs.numeric()).columns))
     return res_array
+
+
+def box_cox_parallel_backend() -> str:
+    """Return a joblib backend suitable for parallelizing the Box-Cox transform in the current environment.
+
+    Frozen (PyInstaller) builds cannot use the ``loky`` backend, so they fall back to ``multiprocessing``
+    (see ``rnalysis.utils.param_typing.PARALLEL_BACKENDS``). This is only ever used from top-level, non-nested
+    call sites (the PCA methods), so ``multiprocessing``'s no-nested-children limitation does not apply.
+    """
+    return 'multiprocessing' if FROZEN_ENV else 'loky'
 
 
 def shift_to_baseline(data: Union[np.ndarray, pl.DataFrame], baseline: float = 0) -> Union[np.ndarray, pl.DataFrame]:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,6 +1,7 @@
 import pytest
 from matplotlib.backend_bases import PickEvent
 
+from rnalysis.utils import generic
 from rnalysis.utils.generic import *
 
 
@@ -35,6 +36,52 @@ def test_standard_box_cox():
     assert res_df.shape == data_df.shape
     assert np.all(res_df.select(pl.first()) == data_df.select(pl.first()))
     assert np.all(res_df.columns == data_df.columns)
+
+
+# Box-Cox each column independently, so splitting the columns across workers gives the same result as the
+# single-process path. It is not guaranteed bit-for-bit: transforming a column-slice of a C-contiguous matrix
+# vs the full matrix can shift numpy's reduction blocking, perturbing some data by ~1e-15 (measured on the
+# real count-matrix fixture; far below anything that affects PCA loadings, cluster assignments, or sort order).
+# The end-to-end loky path is covered against a committed truth file by test_split_by_principal_components.
+_BOX_COX_PARALLEL_TOL = 1e-10
+
+
+@pytest.mark.parametrize('backend', ['threading'])
+def test_parallel_box_cox_matches_serial(backend):
+    rng = np.random.default_rng(0)
+    array = rng.integers(1, 5000, (6, 40)).astype(float)
+    serial = generic._box_cox_fit_transform(array)
+    parallel = generic._parallel_box_cox(array, backend=backend, n_jobs=4)
+    assert parallel.shape == serial.shape
+    assert np.allclose(parallel, serial, rtol=0, atol=_BOX_COX_PARALLEL_TOL)
+
+
+def test_standard_box_cox_parallel_equals_sequential(monkeypatch):
+    # lower the parallelization threshold so a small (fast) array still exercises the parallel branch
+    monkeypatch.setattr(generic, 'BOX_COX_PARALLEL_MIN_COLUMNS', 4)
+    rng = np.random.default_rng(2)
+    array = rng.integers(1, 5000, (6, 30)).astype(float)
+
+    sequential = standard_box_cox(array, parallel_backend='sequential')
+    parallel = standard_box_cox(array, parallel_backend='threading')
+    assert np.allclose(parallel, sequential, rtol=0, atol=_BOX_COX_PARALLEL_TOL)
+
+    data_df = pl.DataFrame([f'ind{i}' for i in range(6)]).with_columns(
+        pl.DataFrame(array, schema=[f'col{j}' for j in range(30)]))
+    seq_df = standard_box_cox(data_df, parallel_backend='sequential')
+    par_df = standard_box_cox(data_df, parallel_backend='threading')
+    assert np.all(par_df.select(pl.first()) == seq_df.select(pl.first()))
+    assert np.allclose(par_df.select(cs.numeric()).to_numpy(),
+                       seq_df.select(cs.numeric()).to_numpy(), rtol=0, atol=_BOX_COX_PARALLEL_TOL)
+
+
+def test_standard_box_cox_default_is_sequential(monkeypatch):
+    # the default call (no parallel_backend) must be byte-identical to the pre-existing serial path
+    monkeypatch.setattr(generic, 'BOX_COX_PARALLEL_MIN_COLUMNS', 4)
+    rng = np.random.default_rng(3)
+    array = rng.integers(1, 5000, (6, 30)).astype(float)
+    reference = StandardScaler().fit_transform(PowerTransformer(method='box-cox').fit_transform(array + 1))
+    assert np.array_equal(standard_box_cox(array), reference)
 
 
 def test_color_generator():


### PR DESCRIPTION
Closes #123. First of the **safe** performance fixes from the hotspot profiling tracker (#128).

## Why

Profiling the "slow PCA/clustering" paths showed the PCA/SVD itself is negligible (**~2 ms**); ~100% of the cost is the **per-gene Box-Cox power transform** that precedes it. `generic.standard_box_cox` → sklearn `PowerTransformer(method='box-cox')` fits one scipy-Brent λ optimization **per column** in a Python loop, and the data is transposed first so **columns = genes** → ~19 ms/gene (measured: 300 genes = 4.6 s, 1345 = 25 s → **~4.7 min for a real 15k-gene dataset**). It runs on the **default** `power_transform=True` path of `pca()`, `sort_by_principal_component()`, and `split_by_principal_components()`.

## What

- `generic.standard_box_cox` gains an **opt-in** `parallel_backend` kwarg that splits the per-column Box-Cox across CPU cores (each column is transformed independently), gated on `BOX_COX_PARALLEL_MIN_COLUMNS = 500` so small inputs skip the spawn overhead. **Default (`'sequential'`) is byte-identical to the old code.**
- The three PCA methods opt in via `generic.box_cox_parallel_backend()` = `loky` from source, `multiprocessing` when frozen. They are **top-level, non-nested** call sites (no internal callers — grep-verified), so `multiprocessing`'s no-nested-children limitation cannot trigger. All clustering/CLICOM sites keep the default sequential path, so **no new nested parallelism** is introduced inside any `joblib.parallel_backend` region.

## Measured

**~3.2× on the 1345-gene fixture (24 s → 7.4 s)**, on a 16-core box; the speedup grows on larger data (less relative spawn overhead).

## Reproducibility (invariant #5)

The parallel result matches the single-process one **up to floating-point precision (~1e-15)**, not bit-for-bit: transforming a column-slice of a C-contiguous matrix rather than the whole matrix can shift numpy's reduction blocking. Verified this is **data-dependent and always ≤ ~6.7e-16** on both the real count-matrix fixture and 5 synthetic seeds at 1345 columns — far below anything that affects PCA loadings, cluster assignments, or sort order. Confirmed against the committed truth files: **`test_split_by_principal_components` passes with the loky path active** on the full fixture. The default sequential path stays byte-identical. Called out in `HISTORY.rst`.

## Testing

- New unit tests in `tests/test_generic.py`: parallel-vs-serial equivalence (deterministic `threading`), the public wrapper's parallel/default paths, and a byte-identity check on the default path. The end-to-end **loky** path is covered by the existing `test_split_by_principal_components` truth-file test.
- `tests/test_generic.py` (100) and the PCA filtering tests (4, incl. truth files) pass locally.
- **Could not run locally:** the frozen (PyInstaller) `multiprocessing` path — please sanity-check that on a frozen build (the `multiprocessing`-when-frozen choice matches the documented `PARALLEL_BACKENDS`, and the call sites are non-nested, but I can't exercise a frozen bundle here).

## Review

Ran an independent clean-context review. Adopted its two valid points (removed `loky` from the unit-test parametrize to cut CI process-spawn flakiness — the loky path is covered by the truth-file test instead; and tightened the mechanism wording). It also asserted the transform is "provably bit-identical" and suggested `array_equal` — I **empirically refuted** that (real fixture + all 5 synthetic seeds at scale are `array_equal=False`, maxdiff ~1e-15), so the conservative tolerance stands.

## Related

Part of tracker #128. The other **safe** items are separate: **#125** (memoize the transform inside CLICOM). **#127** (numba `cache=True`) was **measured and dropped** — it gives no benefit for these kernels (documented on the issue). The **risky** wins (#124 vectorize Box-Cox, #126 CLICOM cliques→bitsets) remain, gated on numeric-equivalence validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
