### PR TITLE
docs: user guides describe enrichment output & FoldChangeFilter as polars, not pandas (#100)

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -955,7 +955,7 @@ A :term:`FoldChangeFilter` object can be calculated from a :term:`CountFilter` o
 
 .. warning:: by default, :term:`FoldChangeFilter` assumes that fold change is calculated as (numerator_reads+1)/(denominator_reads+1), and does not support 0 and inf values. If you load a `csv` file which contains 0 and/or inf values into a :term:`FoldChangeFilter` object, unintended results and interactions may occur.
 
-Unlike other Filter object, the underlying data structure storing the values is a pandas Series and not a pandas DataFrame, and lacks the Columns attribute.
+Unlike other Filter objects, which can hold multiple data columns, a :term:`FoldChangeFilter` stores a single column of fold change values. Like all Filter objects, this data is held in a polars DataFrame.
 
 Loading fold change data from a `csv` file
 ------------------------------------------------
@@ -1400,7 +1400,7 @@ If you don't specify plotting parameters, *RNAlysis* will generate an ontology g
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the GO terms, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the GO terms, and return a polars DataFrame in the following format:
 
 +-------------+------------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |             |       name       |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1511,7 +1511,7 @@ If you don't specify plotting parameters, *RNAlysis* will generate a horizontal 
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the KEGG pathways, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the KEGG pathways, and return a polars DataFrame in the following format:
 
 +-----------+-----------------------------------------------------------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |   KEGG ID |                              name                               |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1613,7 +1613,7 @@ When it is set as 'True', *RNAlysis* will return the Figure object it generated 
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the specified attributes, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the specified attributes, and return a polars DataFrame in the following format:
 
 +----------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |                |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1708,7 +1708,7 @@ When it is set as 'True', *RNAlysis* will return the Figure object it generated 
 
 Non-Categorical Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running non-categorical enrichment analysis will calculate enrichment for each of the specified attributes, and return a pandas DataFrame in the following format:
+Running non-categorical enrichment analysis will calculate enrichment for each of the specified attributes, and return a polars DataFrame in the following format:
 
 +----------------+--------------+-------+--------+----------+----------+-------------+
 |                |    samples   |  obs  |  exp   |   pval   |   padj   | significant |

--- a/docs/source/user_guide_gui.rst
+++ b/docs/source/user_guide_gui.rst
@@ -1134,7 +1134,7 @@ If you don't specify plotting parameters, *RNAlysis* will generate an ontology g
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the GO terms, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the GO terms, and return a polars DataFrame in the following format:
 
 +-------------+------------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |             |       name       |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1216,7 +1216,7 @@ If you don't specify plotting parameters, *RNAlysis* will generate a horizontal 
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the KEGG pathways, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the KEGG pathways, and return a polars DataFrame in the following format:
 
 +-----------+-----------------------------------------------------------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |   KEGG ID |                              name                               |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1290,7 +1290,7 @@ When it is set as 'True', *RNAlysis* will return the Figure object it generated 
 
 Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running enrichment analysis will calculate enrichment for each of the specified attributes, and return a pandas DataFrame in the following format:
+Running enrichment analysis will calculate enrichment for each of the specified attributes, and return a polars DataFrame in the following format:
 
 +----------------+--------------+-----+-------+----------------------+----------+----------+-------------+
 |                |    samples   | obs |   exp | log2_fold_enrichment |   pval   |   padj   | significant |
@@ -1362,7 +1362,7 @@ When it is set as 'True', *RNAlysis* will return the Figure object it generated 
 
 Non-Categorical Enrichment analysis output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Running non-categorical enrichment analysis will calculate enrichment for each of the specified attributes, and return a pandas DataFrame in the following format:
+Running non-categorical enrichment analysis will calculate enrichment for each of the specified attributes, and return a polars DataFrame in the following format:
 
 +----------------+--------------+-------+--------+----------+----------+-------------+
 |                |    samples   |  obs  |  exp   |   pval   |   padj   | significant |

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+DOCS_SOURCE = Path(__file__).resolve().parent.parent / 'docs' / 'source'
+
+# Since the v4.0 migration off pandas, RNAlysis returns polars objects (see issue #100). The
+# hand-written user guides must not describe function outputs or underlying data structures as
+# pandas DataFrames/Series, or users will expect a pandas API that no longer exists.
+STALE_PANDAS_PHRASES = ('pandas DataFrame', 'pandas Series')
+
+
+@pytest.mark.parametrize('guide', ['user_guide.rst', 'user_guide_gui.rst'])
+def test_user_guides_describe_polars_output_not_pandas(guide):
+    text = (DOCS_SOURCE / guide).read_text(encoding='utf-8')
+    found = [phrase for phrase in STALE_PANDAS_PHRASES if phrase in text]
+    assert not found, f"{guide} still describes outputs as {found}; RNAlysis returns polars objects since v4.0"


### PR DESCRIPTION
Closes #100.

## Why
Since the v4.0 migration off pandas, RNAlysis returns **polars** objects, but the hand-written user guides still described enrichment output as "a pandas DataFrame" and `FoldChangeFilter`'s underlying data as "a pandas Series … lacks the Columns attribute". This is the **prose** half of the guides' pandas→polars cleanup (companion to the merged docstring fix #96 / #115). Regenerating the example REPL *outputs* to polars repr is tracked separately in **#110**.

## What
- **Enrichment output sections** (`user_guide.rst` ×4, `user_guide_gui.rst` ×4): "return a **pandas** DataFrame" → "return a **polars** DataFrame". Verified against the source: `go_enrichment`, `kegg_enrichment`, `user_defined_enrichment`, and `non_categorical_enrichment` all document `:rtype: pl.DataFrame`.
- **`FoldChangeFilter`** (`user_guide.rst`): the old sentence claimed a *pandas Series* that *lacks the Columns attribute*. Both are now false — `FoldChangeFilter.df` is a `pl.DataFrame` like every other Filter object (single fold-change value column), and it has a `columns` property. Reworded to: *"Unlike other Filter objects, which can hold multiple data columns, a FoldChangeFilter stores a single column of fold change values. Like all Filter objects, this data is held in a polars DataFrame."*

## Test
- Adds `tests/test_documentation.py` — a lightweight guard asserting neither guide reintroduces "pandas DataFrame"/"pandas Series". RED before the prose fix, GREEN after (`2 passed`). The test only reads the `.rst` files (no `rnalysis` import), so it runs even in minimal environments.

## Notes
- No `HISTORY.rst` entry: pure documentation correction, no behavior/output change (consistent with #96/#108, which added none).
- Out of scope but spotted while verifying: `rnalysis/enrichment.py:1320` still has a stray `:rtype: pandas.DataFrame` docstring — a residual #96 miss (a docstring, not a guide). Flagging for a follow-up rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
