### PR TITLE
Detach widgets before deferred deletion

### DIFF
--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -1114,8 +1114,10 @@ class SetOperationWindow(gui_widgets.MinMaxDialog):
     def update_paremeter_ui(self):
         # delete previous widgets
         try:
-            self.parameter_widgets['help_link'].deleteLater()
-            self.operations_grid.removeWidget(self.parameter_widgets['help_link'])
+            help_link = self.parameter_widgets['help_link']
+            self.operations_grid.removeWidget(help_link)
+            help_link.setParent(None)
+            help_link.deleteLater()
         except KeyError:
             pass
         self.parameter_widgets = {}
@@ -1357,8 +1359,10 @@ class SetVisualizationWindow(gui_widgets.MinMaxDialog):
     def update_parameter_ui(self):
         # delete previous widgets
         try:
-            self.parameter_widgets['help_link'].deleteLater()
-            self.visualization_grid.removeWidget(self.parameter_widgets['help_link'])
+            help_link = self.parameter_widgets['help_link']
+            self.visualization_grid.removeWidget(help_link)
+            help_link.setParent(None)
+            help_link.deleteLater()
         except KeyError:
             pass
         self.parameter_widgets = {}

--- a/rnalysis/gui/gui_widgets.py
+++ b/rnalysis/gui/gui_widgets.py
@@ -2208,5 +2208,7 @@ def get_val_from_widget(widget):
 def clear_layout(layout, exceptions: set = frozenset()):
     while layout.count() > len(exceptions):
         child = layout.takeAt(0)
-        if child.widget() and child.widget() not in exceptions:
-            child.widget().deleteLater()
+        child_widget = child.widget()
+        if child_widget and child_widget not in exceptions:
+            child_widget.setParent(None)
+            child_widget.deleteLater()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -14,6 +14,21 @@ from rnalysis.gui.gui import *
 LEFT_CLICK = QtCore.Qt.MouseButton.LeftButton
 RIGHT_CLICK = QtCore.Qt.MouseButton.RightButton
 
+
+class TeardownTrackingLabel(QtWidgets.QLabel):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.teardown_calls = []
+
+    def setParent(self, parent):
+        self.teardown_calls.append(('setParent', parent))
+        super().setParent(parent)
+
+    def deleteLater(self):
+        self.teardown_calls.append(('deleteLater',))
+        super().deleteLater()
+
+
 @pytest.fixture(autouse=True)
 def pytestqt_graceful_shutdown():
     yield
@@ -1077,6 +1092,19 @@ def test_SetOperationWindow_replacing_canvas_detaches_old_canvas(set_op_window):
     assert old_toolbar.parentWidget() is None
 
 
+def test_SetOperationWindow_replacing_help_link_detaches_old_widget(set_op_window):
+    set_op_window.widgets['radio_button_box'].radio_buttons['Union'].click()
+    old_help_link = TeardownTrackingLabel(set_op_window)
+    set_op_window.operations_grid.addWidget(old_help_link)
+    set_op_window.parameter_widgets['help_link'] = old_help_link
+
+    set_op_window.widgets['radio_button_box'].radio_buttons['Intersection'].click()
+
+    assert set_op_window.operations_grid.indexOf(old_help_link) == -1
+    assert old_help_link.parentWidget() is None
+    assert old_help_link.teardown_calls == [('setParent', None), ('deleteLater',)]
+
+
 @pytest.mark.parametrize('n_selected', [3, 4])
 def test_SetOperationWindow_primary_set_change(qtbot, set_op_window, n_selected):
     for i in range(n_selected):
@@ -1313,6 +1341,19 @@ def test_SetVisualizationWindow_replacing_canvas_detaches_old_canvas(set_vis_win
     # NOTE: the canvas classes shadow QWidget.parent() with a `self.parent` attribute, so query the
     # real Qt parent via parentWidget().
     assert old_canvas.parentWidget() is None
+
+
+def test_SetVisualizationWindow_replacing_help_link_detaches_old_widget(set_vis_window):
+    set_vis_window.widgets['radio_button_box'].radio_buttons['Venn Diagram'].click()
+    old_help_link = TeardownTrackingLabel(set_vis_window)
+    set_vis_window.visualization_grid.addWidget(old_help_link)
+    set_vis_window.parameter_widgets['help_link'] = old_help_link
+
+    set_vis_window.widgets['radio_button_box'].radio_buttons['UpSet Plot'].click()
+
+    assert set_vis_window.visualization_grid.indexOf(old_help_link) == -1
+    assert old_help_link.parentWidget() is None
+    assert old_help_link.teardown_calls == [('setParent', None), ('deleteLater',)]
 
 
 @pytest.mark.parametrize('op_name', [

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -11,6 +11,20 @@ LEFT_CLICK = QtCore.Qt.MouseButton.LeftButton
 RIGHT_CLICK = QtCore.Qt.MouseButton.RightButton
 
 
+class TeardownTrackingLabel(QtWidgets.QLabel):
+    def __init__(self, text=''):
+        super().__init__(text)
+        self.teardown_calls = []
+
+    def setParent(self, parent):
+        self.teardown_calls.append(('setParent', parent))
+        super().setParent(parent)
+
+    def deleteLater(self):
+        self.teardown_calls.append(('deleteLater',))
+        super().deleteLater()
+
+
 def widget_setup(qtbot, widget_class, *args, **kwargs):
     widget = widget_class(*args, **kwargs)
     widget.show()
@@ -117,13 +131,17 @@ def test_MandatoryComboBox_disable(qtbot):
 def test_clear_layout(qtbot):
     qtbot, widget = widget_setup(qtbot, QtWidgets.QWidget)
     layout = QtWidgets.QGridLayout(widget)
-    layout.addWidget(QtWidgets.QSpinBox(), 0, 0)
-    layout.addWidget(QtWidgets.QLineEdit(), 1, 2)
-    layout.addWidget(QtWidgets.QLabel("test"), 3, 3)
+    tracked_child = TeardownTrackingLabel("test")
+    children = [QtWidgets.QSpinBox(), QtWidgets.QLineEdit(), tracked_child]
+    layout.addWidget(children[0], 0, 0)
+    layout.addWidget(children[1], 1, 2)
+    layout.addWidget(children[2], 3, 3)
 
     clear_layout(layout)
 
     assert layout.count() == 0
+    assert all(child.parentWidget() is None for child in children)
+    assert tracked_child.teardown_calls == [('setParent', None), ('deleteLater',)]
 
 
 class FilledComboBox(QtWidgets.QComboBox):


### PR DESCRIPTION
## Summary
- reorder the remaining help-link teardown paths to remove, detach, then schedule deletion
- make `clear_layout()` reparent widgets before `deleteLater()`
- add regression tests that assert both the detached state and the teardown call order

Closes #135.

## Testing
- `pytest tests/test_gui.py::test_SetOperationWindow_replacing_help_link_detaches_old_widget tests/test_gui.py::test_SetVisualizationWindow_replacing_help_link_detaches_old_widget tests/test_gui_widgets.py::test_clear_layout -q` (3 passed)
- `pytest tests/test_gui_widgets.py -q` (424 passed)
- `pytest tests/test_gui.py -q -k '(SetOperationWindow or SetVisualizationWindow) and not canvas_types'` (72 passed)
- `git diff --check`

The existing `test_SetVisualizationWindow_canvas_types[UpSet Plot]` case fails in this Windows/offscreen environment; I reproduced the same failure unchanged on `origin/development` at `5433bfcc`, so it is not caused by this patch.

## Review
A separate clean-context agent reviewed the diff. It identified that the initial tests only checked final parent state; the tests now use instrumented labels to assert `setParent(None)` occurs before `deleteLater()`.

AI assistance: OpenAI Codex was used to implement and test this change, and a separate clean-context agent reviewed the diff.