### PR TITLE
Stream parquet→csv on report export (#137)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ Changed
 * The Principal Component Analysis functions (``pca``, ``sort_by_principal_component``, and ``split_by_principal_components``) now run substantially faster on large datasets, by parallelizing the per-gene Box-Cox power transform across CPU cores. Results are unchanged up to floating-point precision (verified against the test suite's reference outputs).
 * Ensembl ortholog and paralog mapping now caches each gene's homology results in the daily cache, so repeating a mapping (or mapping gene sets that overlap a previous one) no longer re-requests the same data from Ensembl. This reduces load on the Ensembl REST API and speeds up repeated mappings.
 
+Changed
+*******
+* Exporting an analysis report now streams each table straight from parquet to CSV instead of loading the whole table into memory first, reducing peak memory use when exporting reports with large tables.
+
 Fixed
 ******
 * Fixed a bug in ``CountFilter.pairplot`` where the Spearman correlation shown for the first row/column of the plot was computed against the gene-index column instead of a sample, producing an incorrect value (and, with recent NumPy versions, an error). The correlations are now always computed between the correct pair of samples.

--- a/rnalysis/gui/gui_report.py
+++ b/rnalysis/gui/gui_report.py
@@ -287,8 +287,8 @@ class ReportGenerator:
             outfile_path = data_path.joinpath(node.filename)
             suffix = node.filename.suffix.lower()
             if suffix == '.parquet':  # convert parquet files to csv files so users can open them with Excel and such
-                df = io.load_cached_gui_file(node.filename)
-                io.save_table(df, outfile_path.with_suffix('.csv'))
+                # stream the transcode instead of loading the whole table into memory
+                io.stream_cached_parquet_to_csv(node.filename, outfile_path.with_suffix('.csv'))
 
             content: bytes = io.load_cached_gui_file(node.filename, load_as_obj=False)
             if content is not None:

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -327,6 +327,23 @@ def cache_gui_file(item: Union[pl.DataFrame, set, str], filename: str):
         raise TypeError(type(item))
 
 
+def stream_cached_parquet_to_csv(cached_filename: Union[str, Path], dst_path: Union[str, Path]):
+    """Transcode a cached parquet table to CSV by streaming (``scan_parquet`` -> ``sink_csv``), without
+    loading the whole table into memory. Waits for any pending background write to the cached file
+    first, and falls back to an eager load/save for the rare edge cases the streaming engine rejects.
+
+    :param cached_filename: name of the parquet file in the GUI cache directory to transcode.
+    :param dst_path: path of the CSV file to write.
+    """
+    src_path = get_gui_cache_dir().joinpath(cached_filename)
+    flush_gui_cache_writes(src_path)  # the cached parquet may still be mid-write in the background
+    dst_path = Path(dst_path)
+    try:
+        pl.scan_parquet(src_path).sink_csv(dst_path)
+    except Exception:  # the streaming engine can reject odd/edge files; the eager path always works
+        save_table(load_table(src_path), dst_path)
+
+
 def check_changed_version():  # pragma: no cover
     data_dir = get_data_dir()
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -338,9 +338,18 @@ def stream_cached_parquet_to_csv(cached_filename: Union[str, Path], dst_path: Un
     src_path = get_gui_cache_dir().joinpath(cached_filename)
     flush_gui_cache_writes(src_path)  # the cached parquet may still be mid-write in the background
     dst_path = Path(dst_path)
+    streamed = False
     try:
-        pl.scan_parquet(src_path).sink_csv(dst_path)
+        lazy = pl.scan_parquet(src_path)
+        # legacy (pandas-era) session parquet files carry an '__index_level_0__' column that the eager
+        # load_table renames to ''. Streaming would skip that rename, so fall back to eager for those
+        # to keep exported CSVs byte-identical for old sessions. collect_schema() reads metadata only.
+        if '__index_level_0__' not in lazy.collect_schema().names():
+            lazy.sink_csv(dst_path)
+            streamed = True
     except Exception:  # the streaming engine can reject odd/edge files; the eager path always works
+        streamed = False
+    if not streamed:
         save_table(load_table(src_path), dst_path)
 
 

--- a/tests/test_gui_report.py
+++ b/tests/test_gui_report.py
@@ -1,3 +1,4 @@
+import polars as pl
 import pytest
 
 from rnalysis.gui.gui_report import *
@@ -101,3 +102,36 @@ def test_generate_report(report_generator, tmp_path):
     report_file = tmp_path / 'report.html'
     assert report_file.exists()
     assert len(report_generator.graph.nodes) == 9
+
+
+def test_generate_report_streams_parquet_to_csv(report_generator, tmp_path, monkeypatch):
+    monkeypatch.setattr(webbrowser, 'open', lambda *a, **k: None)
+    calls = []
+    real = io.stream_cached_parquet_to_csv
+
+    def spy(cached_filename, dst_path):
+        calls.append((cached_filename, dst_path))
+        return real(cached_filename, dst_path)
+
+    monkeypatch.setattr(io, 'stream_cached_parquet_to_csv', spy)
+
+    df = pl.DataFrame({'': ['g1', 'g2', 'g3'], 'a': [1, 2, 3], 'b': [4.5, None, 6.5]})
+    filename = Path('999_report_stream.parquet')
+    io.cache_gui_file(df, str(filename))
+    io.flush_gui_cache_writes()
+    cache_path = io.get_gui_cache_dir().joinpath(filename)
+    try:
+        report_generator.add_node('Streamed table', 999, [0], 'desc', 'Count matrix', filename)
+        report_generator.generate_report(tmp_path)
+
+        out_csv = tmp_path / 'data' / '999_report_stream.csv'
+        assert calls, 'report export must transcode parquet->csv via the streaming helper'
+        assert out_csv.exists()
+        # the streamed csv must be byte-identical to the eager read_parquet -> write_csv path
+        expected = tmp_path / 'expected.csv'
+        pl.read_parquet(cache_path).write_csv(expected)
+        assert out_csv.read_bytes() == expected.read_bytes()
+    finally:
+        if cache_path.exists():
+            cache_path.unlink()
+        io._reset_gui_cache_writer()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1099,6 +1099,28 @@ def test_stream_cached_parquet_to_csv_matches_eager(gui_cache_writer, tmp_path):
             cache_path.unlink()
 
 
+def test_stream_cached_parquet_to_csv_handles_legacy_index_column(tmp_path):
+    # legacy (pandas-era) session parquet files are copied raw into the cache and carry an
+    # '__index_level_0__' column that the eager load_table renames to ''. The exported CSV must match
+    # that eager output byte-for-byte, not leak the raw column name.
+    df = pl.DataFrame({'__index_level_0__': ['g1', 'g2'], 'a': [1, 2]})
+    filename = 'stream_legacy_index.parquet'
+    get_gui_cache_dir().mkdir(parents=True, exist_ok=True)
+    cache_path = get_gui_cache_dir().joinpath(filename)
+    dst = tmp_path.joinpath('out.csv')
+    try:
+        df.write_parquet(cache_path)  # simulate a raw legacy file placed in the cache by session load
+        stream_cached_parquet_to_csv(filename, dst)
+        assert dst.exists()
+        expected = tmp_path.joinpath('expected.csv')
+        save_table(load_table(cache_path), expected)  # the reference output the old eager path produced
+        assert dst.read_bytes() == expected.read_bytes()
+        assert b'__index_level_0__' not in dst.read_bytes()
+    finally:
+        if cache_path.exists():
+            cache_path.unlink()
+
+
 def test_stream_cached_parquet_to_csv_falls_back_to_eager(gui_cache_writer, tmp_path, monkeypatch):
     df = pl.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
     filename = 'stream_fallback.parquet'

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1082,6 +1082,44 @@ def test_flush_gui_cache_writes_reraises_write_errors(gui_cache_writer):
         flush_gui_cache_writes()
 
 
+def test_stream_cached_parquet_to_csv_matches_eager(gui_cache_writer, tmp_path):
+    df = pl.DataFrame({'': ['g1', 'g2', 'g3'], 'a': [1, 2, 3], 'b': [4.5, None, 6.5], 's': ['x', 'y,z', 'w']})
+    filename = 'stream_unit.parquet'
+    cache_path = get_gui_cache_dir().joinpath(filename)
+    dst = tmp_path.joinpath('out.csv')
+    try:
+        cache_gui_file(df, filename)  # queued as a background write; the transcode must flush it first
+        stream_cached_parquet_to_csv(filename, dst)
+        assert dst.exists()
+        expected = tmp_path.joinpath('expected.csv')
+        pl.read_parquet(cache_path).write_csv(expected)
+        assert dst.read_bytes() == expected.read_bytes()
+    finally:
+        if cache_path.exists():
+            cache_path.unlink()
+
+
+def test_stream_cached_parquet_to_csv_falls_back_to_eager(gui_cache_writer, tmp_path, monkeypatch):
+    df = pl.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    filename = 'stream_fallback.parquet'
+    cache_path = get_gui_cache_dir().joinpath(filename)
+    dst = tmp_path.joinpath('out.csv')
+
+    def boom(*args, **kwargs):
+        raise RuntimeError('streaming engine rejected the file')
+
+    try:
+        cache_gui_file(df, filename)
+        flush_gui_cache_writes()
+        monkeypatch.setattr(pl, 'scan_parquet', boom)
+        stream_cached_parquet_to_csv(filename, dst)  # scan raises -> eager fallback still writes the csv
+        assert dst.exists()
+        assert load_table(dst).equals(df)
+    finally:
+        if cache_path.exists():
+            cache_path.unlink()
+
+
 def test_flush_surfaces_error_from_superseded_write(gui_cache_writer, monkeypatch):
     # an earlier failed write to a path must still surface at the barrier even when a later write to
     # the same path was queued before the flush (guards against dropping the superseded future).


### PR DESCRIPTION
Closes #137. Second deliverable of epic #66. **Stacked on #142 (#136)** — base is `feat/gui-cache-async-barrier` because this uses the `flush_gui_cache_writes` barrier added there. Please merge #142 first, then I'll retarget this to `development` (or it can be merged after #142 lands).

## Problem
Report export transcoded every cached parquet table to CSV by loading the **whole table into memory** (`load_cached_gui_file` → `save_table`), then rewriting it — wasteful for large count matrices.

## Change
- New `io.stream_cached_parquet_to_csv(cached_filename, dst_path)`: streams `pl.scan_parquet(src).sink_csv(dst)` so peak memory stays bounded. It flushes the #136 write-barrier for the source first, and falls back to the eager load/save for edge cases the streaming engine rejects.
- Wired into `gui_report.ReportGenerator.generate_report`, replacing the load-then-save transcode.

## Reproducibility (byte-identical output)
- Verified on the pinned Polars 1.43.2 that `sink_csv` is **byte-identical** to `write_csv` across ints/floats/nulls/inf-NaN/embedded-commas/empty/single-column tables.
- **Back-compat guard (from review):** legacy pandas-era session parquet files are copied *raw* into the cache on session load and carry an `__index_level_0__` column that the eager `load_table` renames to `''`. The helper peeks the parquet schema (metadata-only) and routes those files to the eager path, so exported CSVs stay identical for old sessions. Covered by a regression test.

## Tests (TDD)
`test_io.py`: streamed output byte-identical to eager; legacy `__index_level_0__` handled; eager fallback when scan/sink raises. `test_gui_report.py`: `generate_report` uses the streaming helper and the exported CSV is byte-identical.

## Verification
- `tests/test_gui_report.py` + the streaming `test_io.py` tests → green (17 passed).
- **Not run:** full GUI e2e / R paths.

Independently reviewed with clean context (correctness + spec); the review caught the `__index_level_0__` back-compat gap, now fixed and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y