### PR TITLE
docs: regenerate public-API docstring examples in polars repr (#146)

### DIFF
--- a/rnalysis/enrichment.py
+++ b/rnalysis/enrichment.py
@@ -1284,12 +1284,18 @@ class FeatureSet(set):
             >>> from rnalysis import enrichment, filtering
             >>> d = filtering.Filter("tests/test_files/test_deseq.csv")
             >>> en = enrichment.FeatureSet(d)
-            >>> en.biotypes(ref='tests/biotype_ref_table_for_tests.csv')
-                            gene
-            biotype
-            protein_coding    26
-            pseudogene         1
-            unknown            1
+            >>> en.biotypes_from_ref_table(ref='tests/test_files/biotype_ref_table_for_tests.csv')
+            Biotype Reference Table used: tests/test_files/biotype_ref_table_for_tests.csv
+            shape: (3, 2)
+            ┌────────────────┬───────┐
+            │ biotype        ┆ count │
+            │ ---            ┆ ---   │
+            │ str            ┆ u32   │
+            ╞════════════════╪═══════╡
+            │ protein_coding ┆ 26    │
+            │ pseudogene     ┆ 1     │
+            │ unknown        ┆ 1     │
+            └────────────────┴───────┘
 
         """
 

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -305,22 +305,30 @@ class Filter:
             >>> from rnalysis import filtering
             >>> d = filtering.Filter("tests/test_files/test_deseq.csv")
             >>> d.head()
-                               baseMean  log2FoldChange  ...         pvalue           padj
-            WBGene00000002  6820.755327        7.567762  ...   0.000000e+00   0.000000e+00
-            WBGene00000003  3049.625670        9.138071  ...  4.660000e-302  4.280000e-298
-            WBGene00000004  1432.911791        8.111737  ...  6.400000e-237  3.920000e-233
-            WBGene00000005  4028.154186        6.534112  ...  1.700000e-228  7.800000e-225
-            WBGene00000006  1230.585240        7.157428  ...  2.070000e-216  7.590000e-213
-            <BLANKLINE>
-            [5 rows x 6 columns]
+            shape: (5, 7)
+            ┌────────────────┬─────────────┬────────────────┬──────────┬───────────┬─────────────┬─────────────┐
+            │                ┆ baseMean    ┆ log2FoldChange ┆ lfcSE    ┆ stat      ┆ pvalue      ┆ padj        │
+            │ ---            ┆ ---         ┆ ---            ┆ ---      ┆ ---       ┆ ---         ┆ ---         │
+            │ str            ┆ f64         ┆ f64            ┆ f64      ┆ f64       ┆ f64         ┆ f64         │
+            ╞════════════════╪═════════════╪════════════════╪══════════╪═══════════╪═════════════╪═════════════╡
+            │ WBGene00000002 ┆ 6820.755327 ┆ 7.567762       ┆ 0.142257 ┆ 53.197692 ┆ 0.0         ┆ 0.0         │
+            │ WBGene00000003 ┆ 3049.62567  ┆ 9.138071       ┆ 0.245989 ┆ 37.148359 ┆ 4.6600e-302 ┆ 4.2800e-298 │
+            │ WBGene00000004 ┆ 1432.911791 ┆ 8.111737       ┆ 0.246801 ┆ 32.867521 ┆ 6.4000e-237 ┆ 3.9200e-233 │
+            │ WBGene00000005 ┆ 4028.154186 ┆ 6.534112       ┆ 0.202467 ┆ 32.272543 ┆ 1.7000e-228 ┆ 7.8000e-225 │
+            │ WBGene00000006 ┆ 1230.58524  ┆ 7.157428       ┆ 0.227948 ┆ 31.399325 ┆ 2.0700e-216 ┆ 7.5900e-213 │
+            └────────────────┴─────────────┴────────────────┴──────────┴───────────┴─────────────┴─────────────┘
 
             >>> d.head(3) # return only the first 3 rows
-                               baseMean  log2FoldChange  ...         pvalue           padj
-            WBGene00000002  6820.755327        7.567762  ...   0.000000e+00   0.000000e+00
-            WBGene00000003  3049.625670        9.138071  ...  4.660000e-302  4.280000e-298
-            WBGene00000004  1432.911791        8.111737  ...  6.400000e-237  3.920000e-233
-            <BLANKLINE>
-            [3 rows x 6 columns]
+            shape: (3, 7)
+            ┌────────────────┬─────────────┬────────────────┬──────────┬───────────┬─────────────┬─────────────┐
+            │                ┆ baseMean    ┆ log2FoldChange ┆ lfcSE    ┆ stat      ┆ pvalue      ┆ padj        │
+            │ ---            ┆ ---         ┆ ---            ┆ ---      ┆ ---       ┆ ---         ┆ ---         │
+            │ str            ┆ f64         ┆ f64            ┆ f64      ┆ f64       ┆ f64         ┆ f64         │
+            ╞════════════════╪═════════════╪════════════════╪══════════╪═══════════╪═════════════╪═════════════╡
+            │ WBGene00000002 ┆ 6820.755327 ┆ 7.567762       ┆ 0.142257 ┆ 53.197692 ┆ 0.0         ┆ 0.0         │
+            │ WBGene00000003 ┆ 3049.62567  ┆ 9.138071       ┆ 0.245989 ┆ 37.148359 ┆ 4.6600e-302 ┆ 4.2800e-298 │
+            │ WBGene00000004 ┆ 1432.911791 ┆ 8.111737       ┆ 0.246801 ┆ 32.867521 ┆ 6.4000e-237 ┆ 3.9200e-233 │
+            └────────────────┴─────────────┴────────────────┴──────────┴───────────┴─────────────┴─────────────┘
 
         """
         return self.df.head(n)
@@ -341,28 +349,36 @@ class Filter:
             >>> from rnalysis import filtering
             >>> d = filtering.Filter("tests/test_files/test_deseq.csv")
             >>> d.tail()
-                               baseMean  log2FoldChange  ...        pvalue          padj
-            WBGene00000025  2236.185837        2.477374  ...  1.910000e-81  1.460000e-78
-            WBGene00000026   343.648987       -4.037191  ...  2.320000e-75  1.700000e-72
-            WBGene00000027   175.142856        6.352044  ...  1.580000e-74  1.120000e-71
-            WBGene00000028   219.163200        3.913657  ...  3.420000e-72  2.320000e-69
-            WBGene00000029  1066.242402       -2.811281  ...  1.420000e-70  9.290000e-68
-            <BLANKLINE>
-            [5 rows x 6 columns]
+            shape: (5, 7)
+            ┌────────────────┬─────────────┬────────────────┬──────────┬────────────┬────────────┬────────────┐
+            │                ┆ baseMean    ┆ log2FoldChange ┆ lfcSE    ┆ stat       ┆ pvalue     ┆ padj       │
+            │ ---            ┆ ---         ┆ ---            ┆ ---      ┆ ---        ┆ ---        ┆ ---        │
+            │ str            ┆ f64         ┆ f64            ┆ f64      ┆ f64        ┆ f64        ┆ f64        │
+            ╞════════════════╪═════════════╪════════════════╪══════════╪════════════╪════════════╪════════════╡
+            │ WBGene00000025 ┆ 2236.185837 ┆ 2.477374       ┆ 0.129606 ┆ 19.114626  ┆ 1.9100e-81 ┆ 1.4600e-78 │
+            │ WBGene00000026 ┆ 343.648987  ┆ -4.037191      ┆ 0.219781 ┆ -18.369115 ┆ 2.3200e-75 ┆ 1.7000e-72 │
+            │ WBGene00000027 ┆ 175.142856  ┆ 6.352044       ┆ 0.347777 ┆ 18.264706  ┆ 1.5800e-74 ┆ 1.1200e-71 │
+            │ WBGene00000028 ┆ 219.1632    ┆ 3.913657       ┆ 0.217802 ┆ 17.968851  ┆ 3.4200e-72 ┆ 2.3200e-69 │
+            │ WBGene00000029 ┆ 1066.242402 ┆ -2.811281      ┆ 0.158284 ┆ -17.761002 ┆ 1.4200e-70 ┆ 9.2900e-68 │
+            └────────────────┴─────────────┴────────────────┴──────────┴────────────┴────────────┴────────────┘
 
 
             >>> d.tail(8) # returns the last 8 rows
-                               baseMean  log2FoldChange  ...        pvalue          padj
-            WBGene00000022   365.813048        6.101303  ...  2.740000e-97  2.400000e-94
-            WBGene00000023  3168.566714        3.906719  ...  1.600000e-93  1.340000e-90
-            WBGene00000024   221.925724        4.801676  ...  1.230000e-84  9.820000e-82
-            WBGene00000025  2236.185837        2.477374  ...  1.910000e-81  1.460000e-78
-            WBGene00000026   343.648987       -4.037191  ...  2.320000e-75  1.700000e-72
-            WBGene00000027   175.142856        6.352044  ...  1.580000e-74  1.120000e-71
-            WBGene00000028   219.163200        3.913657  ...  3.420000e-72  2.320000e-69
-            WBGene00000029  1066.242402       -2.811281  ...  1.420000e-70  9.290000e-68
-            <BLANKLINE>
-            [8 rows x 6 columns]
+            shape: (8, 7)
+            ┌────────────────┬─────────────┬────────────────┬──────────┬────────────┬────────────┬────────────┐
+            │                ┆ baseMean    ┆ log2FoldChange ┆ lfcSE    ┆ stat       ┆ pvalue     ┆ padj       │
+            │ ---            ┆ ---         ┆ ---            ┆ ---      ┆ ---        ┆ ---        ┆ ---        │
+            │ str            ┆ f64         ┆ f64            ┆ f64      ┆ f64        ┆ f64        ┆ f64        │
+            ╞════════════════╪═════════════╪════════════════╪══════════╪════════════╪════════════╪════════════╡
+            │ WBGene00000022 ┆ 365.813048  ┆ 6.101303       ┆ 0.291484 ┆ 20.931891  ┆ 2.7400e-97 ┆ 2.4000e-94 │
+            │ WBGene00000023 ┆ 3168.566714 ┆ 3.906719       ┆ 0.190439 ┆ 20.514331  ┆ 1.6000e-93 ┆ 1.3400e-90 │
+            │ WBGene00000024 ┆ 221.925724  ┆ 4.801676       ┆ 0.246313 ┆ 19.494189  ┆ 1.2300e-84 ┆ 9.8200e-82 │
+            │ WBGene00000025 ┆ 2236.185837 ┆ 2.477374       ┆ 0.129606 ┆ 19.114626  ┆ 1.9100e-81 ┆ 1.4600e-78 │
+            │ WBGene00000026 ┆ 343.648987  ┆ -4.037191      ┆ 0.219781 ┆ -18.369115 ┆ 2.3200e-75 ┆ 1.7000e-72 │
+            │ WBGene00000027 ┆ 175.142856  ┆ 6.352044       ┆ 0.347777 ┆ 18.264706  ┆ 1.5800e-74 ┆ 1.1200e-71 │
+            │ WBGene00000028 ┆ 219.1632    ┆ 3.913657       ┆ 0.217802 ┆ 17.968851  ┆ 3.4200e-72 ┆ 2.3200e-69 │
+            │ WBGene00000029 ┆ 1066.242402 ┆ -2.811281      ┆ 0.158284 ┆ -17.761002 ┆ 1.4200e-70 ┆ 9.2900e-68 │
+            └────────────────┴─────────────┴────────────────┴──────────┴────────────┴────────────┴────────────┘
 
         """
         return self.df.tail(n)
@@ -966,12 +982,12 @@ class Filter:
             >>> from rnalysis import filtering
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows whose biotype is 'protein_coding'
-            >>> counts.filter_biotype_from_ref_table('protein_coding',ref='tests/biotype_ref_table_for_tests.csv')
+            >>> counts.filter_biotype_from_ref_table('protein_coding',ref='tests/test_files/biotype_ref_table_for_tests.csv')
             Filtered 9 features, leaving 13 of the original 22 features. Filtered inplace.
 
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows whose biotype is 'protein_coding' or 'pseudogene'
-            >>> counts.filter_biotype_from_ref_table(['protein_coding','pseudogene'],ref='tests/biotype_ref_table_for_tests.csv')
+            >>> counts.filter_biotype_from_ref_table(['protein_coding','pseudogene'],ref='tests/test_files/biotype_ref_table_for_tests.csv')
             Filtered 0 features, leaving 22 of the original 22 features. Filtered inplace.
 
         """
@@ -1287,30 +1303,30 @@ class Filter:
             >>> from rnalysis import filtering
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows that belong to the attribute 'attribute1'
-            >>> counts.filter_by_attribute('attribute1',ref='tests/attr_ref_table_for_examples.csv')
+            >>> counts.filter_by_attribute('attribute1',ref='tests/test_files/attr_ref_table_for_examples.csv')
             Filtered 15 features, leaving 7 of the original 22 features. Filtered inplace.
 
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows that belong to the attributes 'attribute1' OR 'attribute3' (union)
-            >>> counts.filter_by_attribute(['attribute1','attribute3'],ref='tests/attr_ref_table_for_examples.csv')
+            >>> counts.filter_by_attribute(['attribute1','attribute3'],ref='tests/test_files/attr_ref_table_for_examples.csv')
             Filtered 14 features, leaving 8 of the original 22 features. Filtered inplace.
 
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows that belong to both attributes 'attribute1' AND 'attribute3' (intersection)
             >>> counts.filter_by_attribute(['attribute1','attribute3'],mode='intersection',
-            ... ref='tests/attr_ref_table_for_examples.csv')
+            ... ref='tests/test_files/attr_ref_table_for_examples.csv')
             Filtered 19 features, leaving 3 of the original 22 features. Filtered inplace.
 
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows that DON'T belong to either 'attribute1','attribute3' or both
-            >>> counts.filter_by_attribute(['attribute1','attribute3'],ref='tests/attr_ref_table_for_examples.csv',
+            >>> counts.filter_by_attribute(['attribute1','attribute3'],ref='tests/test_files/attr_ref_table_for_examples.csv',
             ... opposite=True)
             Filtered 8 features, leaving 14 of the original 22 features. Filtered inplace.
 
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> # keep only rows that DON'T belong to both 'attribute1' AND 'attribute3'
             >>> counts.filter_by_attribute(['attribute1','attribute3'],mode='intersection',
-            ... ref='tests/attr_ref_table_for_examples.csv',opposite=True)
+            ... ref='tests/test_files/attr_ref_table_for_examples.csv',opposite=True)
             Filtered 3 features, leaving 19 of the original 22 features. Filtered inplace.
 
         """
@@ -1373,7 +1389,7 @@ class Filter:
             >>> from rnalysis import filtering
             >>> counts = filtering.Filter('tests/test_files/counted.csv')
             >>> attribute1,attribute2 = counts.split_by_attribute(['attribute1','attribute2'],
-            ... ref='tests/attr_ref_table_for_examples.csv')
+            ... ref='tests/test_files/attr_ref_table_for_examples.csv')
             Filtered 15 features, leaving 7 of the original 22 features. Filtering result saved to new object.
             Filtered 20 features, leaving 2 of the original 22 features. Filtering result saved to new object.
 
@@ -1628,23 +1644,36 @@ class Filter:
             >>> from rnalysis import filtering
             >>> d = filtering.Filter("tests/test_files/test_deseq.csv")
             >>> # short-form view
-            >>> d.biotypes_from_ref_table(ref='tests/biotype_ref_table_for_tests.csv')
-                            gene
-            biotype
-            protein_coding    26
-            pseudogene         1
-            unknown            1
+            >>> d.biotypes_from_ref_table(ref='tests/test_files/biotype_ref_table_for_tests.csv')
+            Biotype Reference Table used: tests/test_files/biotype_ref_table_for_tests.csv
+            shape: (3, 2)
+            ┌────────────────┬───────┐
+            │ biotype        ┆ count │
+            │ ---            ┆ ---   │
+            │ str            ┆ u32   │
+            ╞════════════════╪═══════╡
+            │ unknown        ┆ 1     │
+            │ protein_coding ┆ 26    │
+            │ pseudogene     ┆ 1     │
+            └────────────────┴───────┘
 
             >>> # long-form view
-            >>> d.biotypes_from_ref_table(long_format=True,ref='tests/biotype_ref_table_for_tests.csv')
-                           baseMean               ...           padj
-                              count         mean  ...            75%            max
-            biotype                               ...
-            protein_coding     26.0  1823.089609  ...   1.005060e-90   9.290000e-68
-            pseudogene          1.0  2688.043701  ...   1.800000e-94   1.800000e-94
-            unknown             1.0  2085.995094  ...  3.070000e-152  3.070000e-152
-            <BLANKLINE>
-            [3 rows x 48 columns]
+            >>> d.biotypes_from_ref_table(long_format=True,ref='tests/test_files/biotype_ref_table_for_tests.csv')
+            Biotype Reference Table used: tests/test_files/biotype_ref_table_for_tests.csv
+            shape: (3, 49)
+            ┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐
+            │ biotype   ┆ baseMean_ ┆ baseMean_ ┆ baseMean_ ┆ … ┆ padj_25%  ┆ padj_50%  ┆ padj_75%  ┆ padj_max │
+            │ ---       ┆ count     ┆ mean      ┆ std       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ ---      │
+            │ str       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ f64       ┆ f64       ┆ f64       ┆ f64      │
+            │           ┆ f64       ┆ f64       ┆ f64       ┆   ┆           ┆           ┆           ┆          │
+            ╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡
+            │ protein_c ┆ 26.0      ┆ 1823.0896 ┆ 1796.5207 ┆ … ┆ 3.8506e-1 ┆ 1.1350e-1 ┆ 1.0051e-9 ┆ 9.2900e- │
+            │ oding     ┆           ┆ 09        ┆ 8         ┆   ┆ 76        ┆ 35        ┆ 0         ┆ 68       │
+            │ pseudogen ┆ 1.0       ┆ 2688.0437 ┆ null      ┆ … ┆ 1.8000e-9 ┆ 1.8000e-9 ┆ 1.8000e-9 ┆ 1.8000e- │
+            │ e         ┆           ┆ 01        ┆           ┆   ┆ 4         ┆ 4         ┆ 4         ┆ 94       │
+            │ unknown   ┆ 1.0       ┆ 2085.9950 ┆ null      ┆ … ┆ 3.0700e-1 ┆ 3.0700e-1 ┆ 3.0700e-1 ┆ 3.0700e- │
+            │           ┆           ┆ 94        ┆           ┆   ┆ 52        ┆ 52        ┆ 52        ┆ 152      │
+            └───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘
 
         """
         # load the Biotype Reference Table
@@ -2379,16 +2408,20 @@ class FoldChangeFilter(Filter):
         :Examples:
             >>> from rnalysis import filtering
             >>> f = filtering.FoldChangeFilter('tests/test_files/fc_1.csv' , 'numerator' , 'denominator')
-            >>> f_background = f.filter_biotype_from_ref_table('protein_coding', ref='tests/biotype_ref_table_for_tests.csv', inplace=False) #keep only protein-coding genes as reference
+            >>> f_background = f.filter_biotype_from_ref_table('protein_coding', ref='tests/test_files/biotype_ref_table_for_tests.csv', inplace=False) #keep only protein-coding genes as reference
             Filtered 9 features, leaving 13 of the original 22 features. Filtering result saved to new object.
-            >>> f_test = f_background.filter_by_attribute('attribute1', ref='tests/attr_ref_table_for_examples.csv', inplace=False)
+            >>> f_test = f_background.filter_by_attribute('attribute1', ref='tests/test_files/attr_ref_table_for_examples.csv', inplace=False)
             Filtered 6 features, leaving 7 of the original 13 features. Filtering result saved to new object.
             >>> rand_test_res = f_test.randomization_test(f_background)
             Calculating...
-               group size  observed fold change  ...      pval  significant
-            0           7              2.806873  ...  0.360264        False
-
-            [1 rows x 5 columns]
+            shape: (1, 5)
+            ┌────────────┬──────────────────────┬──────────────────────┬──────────┬─────────────┐
+            │ group size ┆ observed fold change ┆ expected fold change ┆ pval     ┆ significant │
+            │ ---        ┆ ---                  ┆ ---                  ┆ ---      ┆ ---         │
+            │ f64        ┆ f64                  ┆ f64                  ┆ f64      ┆ bool        │
+            ╞════════════╪══════════════════════╪══════════════════════╪══════════╪═════════════╡
+            │ 7.0        ┆ 2.806873             ┆ 2.510859             ┆ 0.354265 ┆ false       │
+            └────────────┴──────────────────────┴──────────────────────┴──────────┴─────────────┘
 
         """
         # calculate observed and expected mean fold-change, and the set size (n)

--- a/tests/test_api_docstrings.py
+++ b/tests/test_api_docstrings.py
@@ -1,0 +1,33 @@
+import re
+from pathlib import Path
+
+import pytest
+
+RNALYSIS = Path(__file__).resolve().parent.parent / 'rnalysis'
+PUBLIC_API_MODULES = ('filtering.py', 'enrichment.py', 'general.py')
+
+# The public-API docstrings become the auto-generated API reference and the GUI help. Since the v4.0
+# migration off pandas, their :Examples: outputs must be shown in polars repr, not pandas (issue #146,
+# the docstring analog of the guide fix #110). These markers are unambiguous pandas-repr artifacts.
+PANDAS_REPR_FOOTER = re.compile(r'\[\d+ rows x \d+ columns\]')
+
+# A fixture path under tests/ that is not the real tests/test_files/ location is a broken example that
+# raises FileNotFoundError if a user copies it. All bundled fixtures live under tests/test_files/.
+BROKEN_FIXTURE_PATH = re.compile(r'tests/(?!test_files/)[\w./-]+\.csv')
+
+
+@pytest.mark.parametrize('module', PUBLIC_API_MODULES)
+def test_public_api_docstrings_use_polars_repr(module):
+    text = (RNALYSIS / module).read_text(encoding='utf-8')
+    assert '<BLANKLINE>' not in text, f"{module} docstrings still contain a pandas '<BLANKLINE>' repr marker"
+    assert not PANDAS_REPR_FOOTER.search(text), (
+        f"{module} docstrings still contain a pandas '[N rows x M columns]' repr footer; "
+        f"regenerate the :Examples: outputs in polars repr (issue #146)"
+    )
+
+
+@pytest.mark.parametrize('module', PUBLIC_API_MODULES)
+def test_public_api_docstring_example_paths_exist(module):
+    text = (RNALYSIS / module).read_text(encoding='utf-8')
+    broken = sorted(set(BROKEN_FIXTURE_PATH.findall(text)))
+    assert not broken, f"{module} docstring examples reference nonexistent fixture paths {broken} (use tests/test_files/)"


### PR DESCRIPTION
Closes #146. Independent of the guide PRs (#141 merged, #144 open) — this touches the **docstrings** in the `.py` modules, which feed the auto-generated API reference and the GUI help.

## Context
On `development` the docstring type/return **wording** was already migrated to polars (via #96), but the `:Examples:` **output blocks** still render **pandas** repr (`...` truncation, `<BLANKLINE>`, `[N rows x M columns]`, named indexes). This is the docstring analog of the guide fix #110.

## What
Re-ran every stale example against the current polars API (polars 1.43.x) and pasted the real output:
- **`Filter.head` / `Filter.tail`** — both the default and explicit-`n` calls → polars box tables.
- **`Filter.biotypes_from_ref_table`** short + long form.
- **`FoldChangeFilter.randomization_test`** (the function prints its own result table).
- **`FeatureSet.biotypes_from_ref_table`** (enrichment.py) — its example also called a **nonexistent method name** `en.biotypes(...)` (the method was renamed to `biotypes_from_ref_table`); corrected the name too.

Also fixed the **broken fixture paths** that stopped these examples running at all: `tests/<file>.csv` → `tests/test_files/<file>.csv` (**13 occurrences** across `filtering.py` and `enrichment.py` — in `filter_biotype_from_ref_table`, `filter_by_attribute`, `biotypes_from_ref_table`, `randomization_test`, and the enrichment `biotypes_from_ref_table`). All bundled fixtures live under `tests/test_files/`; the bare `tests/…` paths raise `FileNotFoundError` on copy-paste.

## Note on #146's description
When I filed #146 I listed a category of stale **type-wording** based on Guy's `chore/dependency-maintenance` branch — but on `development` that wording is **already polars** (only `.to_pandas()`/`pl.from_pandas`/`import pandas` code remains, which is correct). So this PR is scoped to the **example-output regeneration + broken paths/name** that genuinely remain on `development`. Updated the issue accordingly.

## Reproducibility
Docstrings are **not** run as doctests in CI (`pytest.ini` has no `--doctest-modules`; no `make doctest` in CI). A couple of outputs are non-deterministic (polars `group_by` row order; the randomization p-value), so those pasted values are representative.

## Test
Adds `tests/test_api_docstrings.py` (separate file from `test_documentation.py` to avoid colliding with #144): guards `filtering`/`enrichment`/`general` against pandas-repr artifacts and against fixture paths not under `tests/test_files/`. RED on the base (`filtering.py`: 5 `<BLANKLINE>` + 6 footers + 12 broken paths; `enrichment.py`: 1 broken path + a small-frame pandas repr), GREEN now (`6 passed`). File-read only, no `rnalysis` import.

## Validated
- Outputs generated by running the examples in a local polars-1.43.2 env, spliced verbatim (box chars preserved), CRLF endings preserved.
- `py_compile` + `import rnalysis.filtering` / `rnalysis.enrichment` succeed; `git diff --check` clean.
- **Could not run** the full test suite locally (needs R / network / Qt); changes are docstring text + a file-reading test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
