### PR TITLE
Lazy table-loading path with projection pushdown (#138)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Changed
 * CLICOM ensemble clustering (``CountFilter.split_clicom``) now runs faster, by computing each distinct power-transform/standardization of the data only once per run and reusing it across the many clustering setups that share it, instead of recomputing the identical transform for every setup. Clustering results are bit-for-bit identical.
 * The Principal Component Analysis functions (``pca``, ``sort_by_principal_component``, and ``split_by_principal_components``) now run substantially faster on large datasets, by parallelizing the per-gene Box-Cox power transform across CPU cores. Results are unchanged up to floating-point precision (verified against the test suite's reference outputs).
 * Ensembl ortholog and paralog mapping now caches each gene's homology results in the daily cache, so repeating a mapping (or mapping gene sets that overlap a previous one) no longer re-requests the same data from Ensembl. This reduces load on the Ensembl REST API and speeds up repeated mappings.
+* Importing a gene set from a ``.csv`` or ``.tsv`` file now reads only its first column via a lazy scan, so the rest of the table is no longer loaded into memory, and stray leading/trailing whitespace is trimmed from the gene identifiers so they match how IDs are read from reference and count tables.
 
 Fixed
 ******

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -3693,10 +3693,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @staticmethod
     def _filename_to_gene_set(filename: str):
-        if filename.endswith('.csv'):
-            gene_set = parsing.data_to_set(pl.scan_csv(filename).select(pl.first()).collect())
-        elif filename.endswith('.tsv'):
-            gene_set = parsing.data_to_set(pl.scan_csv(filename, separator='\t').select(pl.first()).collect())
+        if filename.endswith(('.csv', '.tsv')):
+            # read only the first column: projection pushdown avoids materializing the rest of the table,
+            # and load_table_lazy applies the same cleanup (whitespace strip) as a full table load
+            gene_set = parsing.data_to_set(io.load_table_lazy(filename).select(pl.first()).collect())
         else:
             with open(filename) as f:
                 gene_set = {line.strip() for line in f.readlines()}

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -470,6 +470,60 @@ def load_table(filename: Union[str, Path], drop_columns: Union[str, List[str]] =
     return df
 
 
+def load_table_lazy(filename: Union[str, Path]) -> pl.LazyFrame:
+    """
+    Lazily load a CSV, TSV, or Parquet file as a Polars LazyFrame, mirroring :func:`load_table`'s dialect
+    detection and cleanup so that ``load_table_lazy(f).collect()`` equals ``load_table(f)``.
+
+    Returning a LazyFrame lets callers push a projection (``.select``) or predicate (``.filter``) into the
+    scan, so a subset read (e.g. only the first column) never materializes the whole table -- for Parquet
+    this skips reading the unselected column chunks entirely.
+
+    The ``.collect() == load_table(...)`` equivalence holds for any non-empty table. A completely empty
+    file raises on ``.collect()`` (as a bare ``scan_csv`` does) rather than returning an empty DataFrame
+    the way :func:`load_table` does for that edge case.
+
+    :type filename: str or pathlib.Path
+    :param filename: name of the file to be loaded.
+    :return: a Polars LazyFrame over the loaded file.
+    :rtype: polars.LazyFrame
+    """
+    assert isinstance(filename,
+                      (str, Path)), f"Filename must be of type str or pathlib.Path, is instead {type(filename)}."
+    filename = Path(filename)
+    assert filename.exists() and filename.is_file(), f"File '{filename.as_posix()}' does not exist!"
+    assert filename.suffix.lower() in {'.csv', '.tsv', '.txt', '.parquet'}, \
+        f"RNAlysis cannot load files of type '{filename.suffix}'. " \
+        f"Please convert your file to a .csv, .tsv, .txt, or .parquet file and try again."
+
+    if filename.suffix.lower() == '.parquet':
+        lazy = pl.scan_parquet(filename)
+        # handle edge cases of parquet files that were exported from pandas DataFrames
+        names = lazy.collect_schema().names()  # metadata only, does not read the data
+        if '__index_level_0__' in names:
+            others = [name for name in names if name != '__index_level_0__']
+            lazy = lazy.select([pl.col('__index_level_0__').alias('')] + [pl.col(name) for name in others])
+        return lazy
+
+    if filename.suffix.lower() == '.csv':
+        sep = ','
+    elif filename.suffix.lower() == '.tsv':
+        sep = '\t'
+    else:
+        with open(filename) as f:
+            sample = f.readline()
+            sep = csv.Sniffer().sniff(sample).delimiter
+    # infer_schema_length=None resolves dtypes from the whole file, matching load_table's ComputeError
+    # fallback, while projection/predicate pushdown still prunes which columns get materialized on collect
+    lazy = pl.scan_csv(filename, separator=sep, has_header=True, null_values=['nan', 'NaN', 'NA'],
+                       infer_schema_length=None)
+    string_cols = [name for name, dtype in lazy.collect_schema().items() if dtype in (pl.Utf8, pl.String)]
+    # strip whitespace from string columns, then turn any remaining empty string into null
+    lazy = lazy.with_columns([pl.col(col).str.strip_chars() for col in string_cols])
+    lazy = lazy.with_columns([pl.col(col).replace("", None) for col in string_cols])
+    return lazy
+
+
 def save_table(df: pl.DataFrame, filename: Union[str, Path], postfix: str = None):
     """
     save a pandas DataFrame to csv/parquet file.

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2578,6 +2578,15 @@ def test_MainWindow_import_multiple_gene_sets(main_window_with_tabs, monkeypatch
         assert main_window_with_tabs.tabs.widget(i + 5).obj() == truth[i]
 
 
+@pytest.mark.parametrize('suffix,sep', [('.csv', ','), ('.tsv', '\t')])
+def test_MainWindow_filename_to_gene_set_strips_whitespace(tmp_path, suffix, sep):
+    # tabular gene-set imports read the first column via load_table_lazy, which trims stray
+    # whitespace from identifiers so they match reference tables loaded the same way
+    path = tmp_path / f'genes{suffix}'
+    path.write_text(f'gene{sep}score\n WBGene01 {sep}5\nWBGene02{sep}6\n')
+    assert MainWindow._filename_to_gene_set(str(path)) == {'WBGene01', 'WBGene02'}
+
+
 @pytest.mark.parametrize('filename', ['tests/test_files/counted.tsv', 'tests/test_files/test_deseq.csv',
                                       'tests/test_files/test_gene_set.txt'])
 def test_MainWindow_import_gene_set(main_window_with_tabs, monkeypatch, filename):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -181,6 +181,52 @@ def test_load_csv_drop_columns():
         load_table('tests/test_files/counted.csv', drop_columns=['cond1', 'cond6'])
 
 
+@pytest.mark.parametrize('pth', ("tests/test_files/test_load_csv.csv", "tests/test_files/test_load_csv.tsv",
+                                 "tests/test_files/test_load_csv_tabs.txt",
+                                 "tests/test_files/test_load_csv_other_sep.txt", "tests/test_files/counted.csv"))
+def test_load_table_lazy_returns_lazyframe_matching_eager(pth):
+    lazy = load_table_lazy(pth)
+    assert isinstance(lazy, pl.LazyFrame)
+    assert lazy.collect().equals(load_table(pth))
+
+
+def test_load_table_lazy_matches_eager_parquet(tmp_path):
+    df = pl.DataFrame({'': ['a', 'b', 'c'], 'x': [1, 2, 3], 'y': [1.5, 2.5, 3.5]})
+    path = tmp_path / 'plain.parquet'
+    df.write_parquet(path)
+    lazy = load_table_lazy(path)
+    assert isinstance(lazy, pl.LazyFrame)
+    assert lazy.collect().equals(load_table(path))
+
+
+def test_load_table_lazy_handles_legacy_index_column(tmp_path):
+    # pandas-exported parquet carries an '__index_level_0__' column that load_table renames to ''
+    df = pl.DataFrame({'__index_level_0__': ['g1', 'g2'], 'x': [1, 2]})
+    path = tmp_path / 'legacy.parquet'
+    df.write_parquet(path)
+    collected = load_table_lazy(path).collect()
+    assert collected.columns == ['', 'x']
+    assert collected.equals(load_table(path))
+
+
+def test_load_table_lazy_strips_and_nulls_strings(tmp_path):
+    path = tmp_path / 'messy.csv'
+    path.write_text('gene, value ,label\n foo ,1,x\nbar,,\nbaz,3,NA\n,4,z\n')
+    collected = load_table_lazy(path).collect()
+    assert collected.equals(load_table(path))
+    # leading/trailing whitespace stripped from string cells, empty string -> null
+    assert collected.get_column('gene').to_list() == ['foo', 'bar', 'baz', None]
+
+
+def test_load_table_lazy_projection_pushdown_skips_unselected_columns(tmp_path):
+    wide = pl.DataFrame({f'c{i}': list(range(4)) for i in range(10)})
+    path = tmp_path / 'wide.parquet'
+    wide.write_parquet(path)
+    plan = load_table_lazy(path).select(pl.first()).explain()
+    # only the first of the 10 columns is read from the parquet file
+    assert 'PROJECT 1/10 COLUMNS' in plan
+
+
 def test_save_csv():
     try:
         df = pl.read_csv('tests/test_files/enrichment_hypergeometric_res.csv')


### PR DESCRIPTION
Part of epic #66. Closes #138.

## What
Adds `io.load_table_lazy(filename) -> pl.LazyFrame`, a lazy twin of `load_table` that mirrors its dialect detection and cleanup so that **`load_table_lazy(f).collect()` equals `load_table(f)`** for any non-empty table. Returning a `LazyFrame` lets callers push a projection (`.select`) or predicate (`.filter`) into the scan — for **Parquet** (columnar) this skips reading the unselected column chunks entirely.

The one production consumer routed through it is `MainWindow._filename_to_gene_set`: importing a gene set from a `.csv`/`.tsv` now reads **only the first column** via projection pushdown instead of materializing the whole table.

## Scoping note (re: the issue's "preview" path)
The issue lists "report node thumbnails / previews" as a candidate. On inspection those previews are **baked-in HTML generated from in-memory objects** at node-creation time (`_format_report_desc` → `parsing.df_to_html(obj)`), and the tab table preview renders the already-loaded `self.filter_obj.df` — neither reads from disk, so there is no subset disk-read there to make lazy. **Gene-set extraction is the genuine subset disk-read path**, so that's what's routed. The reproducibility-critical `filtering.py` reference/analysis reads are deliberately left for #139 (lazy Filter query plans, plan-first).

## Behavior change (intentional)
Gene-set import now **trims leading/trailing whitespace** from identifiers (the old raw `scan_csv` path did not), so IDs match how they're read from reference and count tables via `load_table`. This actually aligns production with the *existing* `test_MainWindow_import_gene_set` truth, which was already built from `io.load_table(...)`.

## Design notes
- **CSV uses `infer_schema_length=None`**: resolves dtypes from the whole file, matching `load_table`'s `ComputeError`→full-inference fallback in *both* the clean and fallback cases (verified: an int column that turns float past row 100 yields identical `Float64` output). Projection/predicate pushdown still prunes which columns get materialized on collect.
- **Parquet `__index_level_0__`** (pandas-era files) is renamed to `''` lazily via a metadata-only `collect_schema()` peek, exactly as `load_table` does eagerly.
- **`load_table` is left completely untouched** — zero risk to the reproducibility invariant. This accepts some duplication between the eager and lazy loaders in exchange for not modifying the reproducibility-critical path.
- **Empty-file edge case**: a completely empty file raises on `.collect()` (as a bare `scan_csv` does) rather than returning an empty frame. Verified the gene-set consumer's behavior is *identical* old-vs-new here (both raise on 0-byte, both yield an empty set on header-only), so there's no user-facing regression; documented in the docstring.

## Tests (TDD, red→green)
- `test_io.py`: `load_table_lazy` returns a `LazyFrame` whose `.collect()` equals `load_table` across csv/tsv/txt(2 seps)/counted.csv + parquet; legacy `__index_level_0__` rename; string strip + empty→null; and a projection-pushdown assertion (`PROJECT 1/10 COLUMNS`).
- `test_gui.py`: `_filename_to_gene_set` strips whitespace for `.csv`/`.tsv`; existing `import_gene_set` still passes.
- Ran the io load/save/cache subset (42 passed) — no regression from the additive change.

**Not run:** full GUI e2e / R paths. Note: `test_MainWindow_copy_gene_set` fails on this machine due to OS-clipboard access — confirmed pre-existing (fails identically on a sibling branch without these changes) and unrelated.

## Base
Branched off `development` and **independent** of the #136/#137 stack (does not consume their APIs), so it can be reviewed/merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)