### PR TITLE
Fix removed/deprecated Polars call sites (1.43 compat)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Changed
 
 Fixed
 ******
+* Fixed a bug where averaging replicate samples (``CountFilter.average_replicate_samples``) crashed when the averaging function was set to ``'median'`` or ``'geometric_mean'`` (both selectable in the GUI), because the underlying Polars calls no longer existed in current Polars versions. Both options now work correctly, computing the row-wise median / geometric mean across each group of replicate columns.
+* Restored compatibility with current Polars versions in two internal code paths that relied on since-removed Polars behavior: loading a table while skipping comment lines, and parsing annotation scores during gene-ID translation.
 * Fixed a bug in ``CountFilter.pairplot`` where the Spearman correlation shown for the first row/column of the plot was computed against the gene-index column instead of a sample, producing an incorrect value (and, with recent NumPy versions, an error). The correlations are now always computed between the correct pair of samples.
 * Fixed a bug where mapping orthologs through the OrthoInspector service could hang indefinitely when one of its databases stopped responding (OrthoInspector relocated its API, and its largest database can stall). OrthoInspector requests now use a timeout, target OrthoInspector's current API host directly, and automatically fall back to the next available database.
 * Fixed a bug where gene-ID translation and enrichment analyses (which rely on UniProt) could intermittently fail with an ``HTTP 400`` error while waiting for a UniProt ID-mapping job, especially when several analyses ran at once. The job-status check now retries such transient errors with backoff instead of failing.

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -3679,10 +3679,10 @@ class CountFilter(Filter):
                         self.df.select(pl.col(group)).mean_horizontal().alias(new_name))
                 elif function == 'median':
                     averaged_df = averaged_df.with_columns(
-                        self.df.select(pl.col(group)).median_horizontal().alias(new_name))
+                        self.df.select(pl.concat_list(pl.col(group)).list.median().alias(new_name)))
                 else:
-                    averaged_df = averaged_df.with_columns(
-                        self.df.select(pl.col(group).apply(lambda x: gmean(x)).alias(new_name)))
+                    group_gmean = gmean(self.df.select(pl.col(group)).to_numpy(), axis=1)
+                    averaged_df = averaged_df.with_columns(pl.Series(new_name, group_gmean))
 
             else:
                 raise TypeError(f"'sample_list' cannot contain objects of type {type(group)}.")

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -423,7 +423,7 @@ def load_table(filename: Union[str, Path], drop_columns: Union[str, List[str]] =
 
     kwargs = {}
     if comment is not None:
-        kwargs['comment_char'] = comment
+        kwargs['comment_prefix'] = comment
     if filename.suffix.lower() == '.parquet':
         df = pl.read_parquet(filename)
         # handle edge cases of parquet files that were exported from pandas DataFrames
@@ -2166,7 +2166,7 @@ class GeneIDTranslator:
         if 'Annotation' in df.columns:
             if df['Annotation'].dtype not in pl.FLOAT_DTYPES:
                 df = df.lazy().with_columns(
-                    Annotation=pl.col('Annotation').replace('', '0', return_dtype=pl.datatypes.Int16))
+                    Annotation=pl.col('Annotation').replace('', '0').cast(pl.datatypes.Int16))
             else:
                 df = df.lazy()
             df = df.sort('Annotation', descending=True).drop('Annotation').collect()

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1880,6 +1880,25 @@ def test_avg_subsamples(sample_list, truth_path, basic_countfilter):
     assert np.isclose(res.drop(cs.first()), truth.drop(cs.first()), atol=0, rtol=0.001).all()
 
 
+@pytest.mark.parametrize('function', ['mean', 'median', 'geometric_mean'])
+def test_avg_subsamples_functions(function, basic_countfilter):
+    sample_list = [['cond1', 'cond2'], ['cond3', 'cond4']]
+    res = basic_countfilter._avg_subsamples(sample_list, function=function, new_column_names='auto')
+
+    src = basic_countfilter.df
+    numeric = res.drop(cs.first()).to_numpy()
+    for i, group in enumerate(sample_list):
+        group_vals = src.select(group).to_numpy()
+        if function == 'mean':
+            expected = group_vals.mean(axis=1)
+        elif function == 'median':
+            expected = np.median(group_vals, axis=1)
+        else:
+            with np.errstate(divide='ignore'):  # rows containing a zero -> geometric mean 0
+                expected = np.exp(np.log(group_vals).mean(axis=1))  # geometric mean, row-wise
+        assert np.allclose(numeric[:, i], expected, rtol=1e-6)
+
+
 @pytest.mark.parametrize('input_file,expected_triplicates',
                          [('tests/test_files/counted.csv', [['cond1', 'cond2', 'cond3'], ['cond4']]),
                           ('tests/test_files/counted_6cols.csv',

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -181,6 +181,14 @@ def test_load_csv_drop_columns():
         load_table('tests/test_files/counted.csv', drop_columns=['cond1', 'cond6'])
 
 
+def test_load_csv_with_comment(tmp_path):
+    pth = tmp_path / 'commented.csv'
+    pth.write_text('# this is a comment line\nidxcol,othercol\none,4\ntwo,5\nthree,6\n')
+    truth = pl.DataFrame({'idxcol': ['one', 'two', 'three'], 'othercol': [4, 5, 6]})
+    loaded = load_table(pth, comment='#')
+    assert loaded.equals(truth)
+
+
 def test_save_csv():
     try:
         df = pl.read_csv('tests/test_files/enrichment_hypergeometric_res.csv')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -189,6 +189,18 @@ def test_load_csv_with_comment(tmp_path):
     assert loaded.equals(truth)
 
 
+def test_format_annotations():
+    # 'From' -> 'To' mappings, ranked by descending 'Annotation' score; the highest-scored mapping wins,
+    # duplicates are collected in score order, and the score column is dropped from the output.
+    results = ['From\tTo\tAnnotation',
+               'geneA\tPa\t3.0',
+               'geneA\tPb\t5.0',
+               'geneB\tPc\t2.0']
+    output_dict, duplicates = GeneIDTranslator.format_annotations(results)
+    assert output_dict == {'geneB': 'Pc'}
+    assert duplicates == {'geneA': ['Pb', 'Pa']}  # Pb (5.0) ranked above Pa (3.0)
+
+
 def test_save_csv():
     try:
         df = pl.read_csv('tests/test_files/enrichment_hypergeometric_res.csv')


### PR DESCRIPTION
## What & why

Fixes four Polars call sites that broke or were deprecated under the `>=1.43.2,<1.44` pin. Surfaced by the deprecation audit in #140 and extracted here as standalone bug fixes (kept separate from #140's idioms work).

Two of these are **live crashes on GUI-selectable options**:

| Fix | Before (Polars 1.43 behavior) | After |
|-----|-------------------------------|-------|
| `CountFilter.average_replicate_samples(function='geometric_mean')` | `Expr.apply` **removed** → `AttributeError`; and the logic was element-wise (wrong) | row-wise `scipy.gmean(..., axis=1)` across each group's replicate columns |
| `CountFilter.average_replicate_samples(function='median')` | `DataFrame.median_horizontal()` **doesn't exist** → `AttributeError` | row-wise `pl.concat_list(...).list.median()` |
| `io.load_table(comment=...)` | `read_csv(comment_char=)` **removed kwarg** → `TypeError` | `comment_prefix` |
| `GeneIDTranslator.format_annotations` | `replace(..., return_dtype=)` **deprecated** → warning | `.replace(...).cast(...)` (empirically proven identical output across String/Int64/numeric/non-numeric/empty inputs) |

The two averaging options crashed before, so no reproducible numeric output is being changed — the new outputs are the first correct ones. Both are documented under **Fixed** in `HISTORY.rst`.

## Tests (TDD)

- `test_avg_subsamples_functions` — parametrized over `mean` / `median` / `geometric_mean`, asserting row-wise results against independent NumPy oracles (the geometric-mean oracle uses `exp(mean(log(x)))`, not `scipy.gmean`, so it's non-circular). `median`/`geometric_mean` were red (`AttributeError`) before the fix.
- `test_load_csv_with_comment` — `load_table(comment='#')` now skips comment lines (was `TypeError`).
- `test_format_annotations` — covers the annotation-score sort + duplicate-collection logic around the changed `replace()/cast()` hunk.

Ran locally (conda env, Polars 1.43.2): all changed-area tests green. **Not run:** full suite, R / network / Qt paths.

## Review

Passed a two-axis clean-context review (Standards + Spec). Spec: all four fixes verified correct, row-wise, non-circular, no scope creep. Standards: the one finding (missing test for the `format_annotations` hunk) is addressed by the follow-up commit.

## Notes

- Out of scope, logged on #140: `pl.NUMERIC_DTYPES`/`pl.FLOAT_DTYPES` (deprecated in Polars 1.0) and the pre-existing vestigial non-float branch of `format_annotations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
