### PR TITLE
Fix Windows-only UnicodeDecodeError in user-guide doc test

### DIFF
--- a/tests/test_docs_user_guide_examples.py
+++ b/tests/test_docs_user_guide_examples.py
@@ -7,8 +7,11 @@ GUI_GUIDE = DOCS_DIR / 'user_guide_gui.rst'
 
 
 def test_user_guide_examples_use_current_api_names_and_paths():
-    user_guide = USER_GUIDE.read_text()
-    gui_guide = GUI_GUIDE.read_text()
+    # The guides contain non-ASCII characters (e.g. Polars table-repr box-drawing glyphs), so the
+    # encoding must be pinned to UTF-8 -- otherwise read_text() uses the platform default (cp1252 on
+    # Windows), which fails to decode them and breaks this test on Windows only.
+    user_guide = USER_GUIDE.read_text(encoding='utf-8')
+    gui_guide = GUI_GUIDE.read_text(encoding='utf-8')
 
     assert 'normalize_quantile' not in user_guide
     assert 'normalize_quantile' not in gui_guide


### PR DESCRIPTION
## What & why

`tests/test_docs_user_guide_examples.py::test_user_guide_examples_use_current_api_names_and_paths` reads the user-guide `.rst` files with `Path.read_text()` and **no `encoding`**, so it falls back to the platform default — **cp1252 on Windows**.

Since #110 regenerated the guides with Polars table reprs, the files contain box-drawing glyphs (e.g. `┐` = U+2510, whose UTF-8 bytes include `0x90`). cp1252 can't decode `0x90`, so the test raised `UnicodeDecodeError` on **Windows CI only** — macOS/Linux default to UTF-8 and passed. It's latent on `development` (the merge that introduced the glyphs apparently never ran the full Windows matrix); it surfaced on an unrelated Windows PR run.

## Fix

Pin both reads to `encoding='utf-8'`, making the test deterministic across platforms/locales.

## Verification

On Windows, reading `docs/source/user_guide.rst`:
- `encoding='cp1252'` → `UnicodeDecodeError: byte 0x90 in position 17676` (the exact CI error)
- `encoding='utf-8'` → OK

`pytest tests/test_docs_user_guide_examples.py` passes. It was already green on macOS/Linux and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
