### PR TITLE
refactor(annotation): Polars-native GTF/GFF parsing, byte-identical (PR-B, #151)

### DIFF
--- a/rnalysis/utils/genome_annotation.py
+++ b/rnalysis/utils/genome_annotation.py
@@ -1,50 +1,177 @@
+"""
+Parsing and length/attribute extraction for genome-annotation files (GTF and GFF3).
+
+This module is the single home for all GTF/GFF parsing in RNAlysis. The three public helpers
+(:func:`map_transcripts_to_genes`, :func:`get_genomic_feature_lengths`, :func:`map_gene_to_attr`) are
+consumed from ``filtering`` and ``fastq``; their signatures and dict return-types are a stable contract.
+
+Internally the pipeline is Polars-native: the file is scanned with :func:`pl.scan_csv`, one row per line,
+and attribute values are pulled out column-wise with anchored regular expressions (see
+:func:`_extract_gtf_attribute` / :func:`_extract_gff3_attribute`). The per-string dict parsers
+:func:`parse_gtf_attributes` / :func:`parse_gff3_attributes` are kept here (and re-exported from
+``utils.parsing`` for backwards compatibility) but are no longer on the hot path.
+"""
+import re
 import warnings
 from pathlib import Path
 from typing import Literal, Union
 
 import numpy as np
+import polars as pl
 from scipy.stats.mstats import gmean
 
-from rnalysis.utils import generic, parsing, validation
+from rnalysis.utils import generic, validation
 from rnalysis.utils.param_typing import LEGAL_GENE_LENGTH_METHODS
+
+# Read whole annotation lines as a single Polars column: pick a field separator that never occurs in a
+# GTF/GFF file, so scan_csv yields one row per line and we split on the real '\t' ourselves. This lets us
+# reproduce the two functions' divergent handling of malformed (wrong-column-count) lines exactly:
+# map_transcripts_to_genes raises, while get_genomic_feature_lengths silently skips.
+_LINE_SEP = '\x01'
+_N_COLUMNS = 9
+_FEATURE_IDX, _START_IDX, _END_IDX, _ATTR_IDX = 2, 3, 4, 8
+
+
+def parse_gtf_attributes(attr_str: str):
+    attributes_dict = {}
+    for this_attr in attr_str.split('; '):
+        this_attr = this_attr.strip()
+        key_end = this_attr.find(' ')
+        if key_end == -1:
+            continue
+        key = this_attr[:key_end]
+        val_start = this_attr.find('"', key_end)
+        val_end = this_attr.find('"', val_start + 1)
+        val = this_attr[val_start + 1:val_end]
+        attributes_dict[key] = val
+    return attributes_dict
+
+
+def parse_gff3_attributes(attr_str: str):
+    attributes_dict = {}
+    for this_attr in attr_str.rstrip().split(';'):
+        this_attr = this_attr.strip()
+        if len(this_attr) == 0:
+            continue
+        key, val = this_attr.split('=')
+        val = val.split(',')
+        if len(val) == 1:
+            val = val[0]
+        attributes_dict[key] = val
+    return attributes_dict
+
+
+def _extract_gtf_attribute(attr_col: pl.Expr, key: str) -> pl.Expr:
+    """Column-wise extraction of a GTF attribute value (``key "value";``).
+
+    The key is anchored on a start-of-string / ``;`` boundary so that, e.g., extracting ``gene_id`` does
+    **not** match the tail of a compound key like ``havana_gene_id`` (correctness item #3). Returns null
+    where the key is absent, mirroring ``key not in parse_gtf_attributes(...)``. If a key occurs more than
+    once in a line (non-standard), the first occurrence wins; standard GTF attribute keys are unique.
+    """
+    pattern = rf'(?:^|;)\s*{re.escape(key)}\s+"([^"]*)"'
+    return attr_col.str.extract(pattern, 1)
+
+
+def _extract_gff3_attribute(attr_col: pl.Expr, key: str) -> pl.Expr:
+    """Column-wise extraction of a GFF3 attribute value (``key=value``), anchored like the GTF variant."""
+    pattern = rf'(?:^|;)\s*{re.escape(key)}=([^;]*)'
+    return attr_col.str.extract(pattern, 1)
+
+
+def _scan_annotation_lines(path: Union[str, Path]) -> pl.LazyFrame:
+    """Scan an annotation file into one row per (non-comment) line, split into its tab-separated fields.
+
+    Yields columns ``_fields`` (List[str]) and ``_n`` (field count) so callers can enforce the 9-column
+    rule themselves. ``quote_char=None`` keeps the literal ``"`` characters of GTF values intact.
+    """
+    return (pl.scan_csv(path, separator=_LINE_SEP, has_header=False, comment_prefix='#',
+                        quote_char=None, schema={'raw': pl.String})
+            .with_columns(pl.col('raw').str.split('\t').alias('_fields'))
+            .with_columns(pl.col('_fields').list.len().alias('_n')))
+
+
+def _read_annotation_records(path: Union[str, Path], file_type: Literal['gtf', 'gff3']) -> pl.DataFrame:
+    """Materialize the feature records needed for length aggregation.
+
+    Malformed lines (``_n != 9``) are silently dropped, reproducing ``get_genomic_feature_lengths``'s
+    original skip-and-continue behaviour. Columns: ``feature``, ``start``, ``end``, ``_transcript`` (this
+    feature's own id, for transcript/mRNA rows), ``_gene`` (its parent gene, for transcript/mRNA rows) and
+    ``_parents`` (List[str] of parent transcript ids, for exon rows).
+    """
+    base = _scan_annotation_lines(path).filter(pl.col('_n') == _N_COLUMNS).select(
+        pl.col('_fields').list.get(_FEATURE_IDX).alias('feature'),
+        pl.col('_fields').list.get(_START_IDX).cast(pl.Int64).alias('start'),
+        pl.col('_fields').list.get(_END_IDX).cast(pl.Int64).alias('end'),
+        pl.col('_fields').list.get(_ATTR_IDX).alias('_attr'),
+    )
+    if file_type == 'gtf':
+        records = base.with_columns(
+            _extract_gtf_attribute(pl.col('_attr'), 'transcript_id').alias('_transcript'),
+            _extract_gtf_attribute(pl.col('_attr'), 'gene_id').alias('_gene'),
+        ).with_columns(pl.concat_list(pl.col('_transcript')).alias('_parents'))
+    else:  # gff3: a transcript's id is its own ID, its gene is Parent; an exon's Parent may be comma-separated
+        records = base.with_columns(
+            _extract_gff3_attribute(pl.col('_attr'), 'ID').alias('_transcript'),
+            _extract_gff3_attribute(pl.col('_attr'), 'Parent').alias('_gene'),
+        ).with_columns(_extract_gff3_attribute(pl.col('_attr'), 'Parent').str.split(',').alias('_parents'))
+    return records.collect()
+
+
+def _sum_exon_lengths_per_parent(exons: pl.DataFrame) -> dict:
+    """Sum exon lengths onto each parent transcript. A shared exon (multiple parents) is added to each,
+    preserving the GFF3 comma-separated ``Parent=a,b`` semantics (correctness item #4)."""
+    # exon _parents lists always hold >=1 parent, so empty_as_null is immaterial here; set it explicitly to
+    # silence the Polars 1.x deprecation warning and pin behaviour across the 2.0 default change.
+    grouped = exons.explode('_parents', empty_as_null=False).group_by('_parents').agg(pl.col('_length').sum())
+    return dict(zip(grouped['_parents'].to_list(), grouped['_length'].to_list()))
 
 
 def map_transcripts_to_genes(gtf_path: Union[str, Path], use_name: bool = False, use_version: bool = True,
                              split_ids: bool = True):
     validation.validate_genome_annotation_file(gtf_path, accept_gff3=False)
 
-    mapping = {}
-    with open(gtf_path, errors="ignore") as f:
-        for i, line in enumerate(f.readlines()):
-            if len(line) == 0 or line[0] == '#':
-                continue
-            line_split = line.strip().split('\t')
-            if len(line_split) != 9:
-                raise ValueError(f'Invalid GTF format at line #{i + 1}: "{line}"')
-            if line_split[2] == 'transcript':
-                attributes = line_split[8]
-                attributes_dict = parsing.parse_gtf_attributes(attributes)
-                if 'transcript_id' not in attributes_dict or 'gene_id' not in attributes_dict:
-                    continue
+    df = _scan_annotation_lines(gtf_path).collect()
+    malformed = df.filter(pl.col('_n') != _N_COLUMNS)
+    if malformed.height:
+        raise ValueError(f'Invalid GTF format: expected 9 tab-separated columns but got '
+                         f'{malformed["_n"][0]} in line: "{malformed["raw"][0]}"')
 
-                transcript_id = attributes_dict['transcript_id'].split(".")[0] if split_ids else attributes_dict[
-                    'transcript_id']
-                gene_id = attributes_dict['gene_id'].split(".")[0] if split_ids else attributes_dict['gene_id']
-                if use_version:
-                    if 'transcript_version' in attributes_dict and 'gene_version' in attributes_dict:
-                        transcript_id += '.' + attributes_dict['transcript_version']
-                        gene_id += '.' + attributes_dict['gene_version']
-                gene_name = None
-                if use_name:
-                    if 'gene_name' not in attributes_dict:
-                        continue
-                    gene_name = attributes_dict['gene_name']
+    transcripts = df.lazy().select(
+        pl.col('_fields').list.get(_FEATURE_IDX).alias('feature'),
+        pl.col('_fields').list.get(_ATTR_IDX).alias('_attr'),
+    ).filter(pl.col('feature') == 'transcript').with_columns(
+        _extract_gtf_attribute(pl.col('_attr'), 'transcript_id').alias('transcript_id'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_id').alias('gene_id'),
+        _extract_gtf_attribute(pl.col('_attr'), 'transcript_version').alias('transcript_version'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_version').alias('gene_version'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_name').alias('gene_name'),
+    ).filter(pl.col('transcript_id').is_not_null() & pl.col('gene_id').is_not_null())
 
-                if transcript_id in mapping:
-                    continue
+    if split_ids:
+        transcripts = transcripts.with_columns(
+            pl.col('transcript_id').str.split('.').list.first().alias('transcript_id'),
+            pl.col('gene_id').str.split('.').list.first().alias('gene_id'),
+        )
+    if use_version:
+        # a version suffix is appended only when BOTH transcript_version and gene_version are present
+        both_versions = pl.col('transcript_version').is_not_null() & pl.col('gene_version').is_not_null()
+        transcripts = transcripts.with_columns(
+            pl.when(both_versions).then(pl.col('transcript_id') + '.' + pl.col('transcript_version'))
+            .otherwise(pl.col('transcript_id')).alias('transcript_id'),
+            pl.when(both_versions).then(pl.col('gene_id') + '.' + pl.col('gene_version'))
+            .otherwise(pl.col('gene_id')).alias('gene_id'),
+        )
+    if use_name:
+        transcripts = transcripts.filter(pl.col('gene_name').is_not_null())
+        value = pl.col('gene_name')
+    else:
+        value = pl.col('gene_id')
 
-                mapping[transcript_id] = gene_name if use_name else gene_id
-    return mapping
+    # first-wins on duplicate transcript ids (e.g. WormBase ids collapsed by split_ids)
+    result = transcripts.select(pl.col('transcript_id').alias('key'), value.alias('val')).unique(
+        subset=['key'], keep='first', maintain_order=True).collect()
+    return dict(zip(result['key'].to_list(), result['val'].to_list()))
 
 
 def get_genomic_feature_lengths(gtf_path: Union[str, Path], feature_type: Literal['gene', 'transcript'],
@@ -55,70 +182,39 @@ def get_genomic_feature_lengths(gtf_path: Union[str, Path], feature_type: Litera
     assert method in method_funcs, f"Illegal method: '{method}'."
     file_type = validation.validate_genome_annotation_file(gtf_path)
 
-    transcript_lengths = {}
-    transcripts_to_genes = {}
-    with open(gtf_path, errors="ignore") as f:
-        for line in f.readlines():
-            if line.startswith('#'):  # skip comments
-                continue
-            split = line.rstrip().split('\t')
-            if len(split) != 9:  # skip invalid lines
-                continue
-            this_feature_type = split[2]
-            attributes_dict = parsing.parse_gtf_attributes(split[8]) if file_type == 'gtf' else \
-                parsing.parse_gff3_attributes(split[8])
-            # map transcripts/mRNAs to their parent gene
-            if this_feature_type == 'transcript' or this_feature_type == 'mRNA':
-                transcript = attributes_dict['ID'] if file_type == 'gff3' else attributes_dict['transcript_id']
-                gene_id = attributes_dict['Parent'] if file_type == 'gff3' else attributes_dict['gene_id']
-                transcripts_to_genes[transcript] = gene_id
-            # get exon length info
-            elif this_feature_type == 'exon':
-                start, end = int(split[3]), int(split[4])
-                exon_length = end - start + 1
-                transcript_ids = attributes_dict['Parent'] if file_type == 'gff3' else \
-                    attributes_dict['transcript_id']
-                # for 'merged exons' method, map the exons directly to the gene IDs, and
-                # keep track of the interval of this exon. it will be used later.
-                # No need to add each exon multiple times if it belongs to multiple transcripts.
-                if method == 'merged_exons' and feature_type == 'gene':
-                    gene_id = transcripts_to_genes[parsing.data_to_list(transcript_ids)[0]]
-                    if gene_id not in transcript_lengths:
-                        transcript_lengths[gene_id] = []
-                    transcript_lengths[gene_id].append((start, end))
-                else:
-                    # map the exon lengths to their parent transcript/transcripts
-                    for this_id in parsing.data_to_list(transcript_ids):
-                        transcript_lengths[this_id] = transcript_lengths.get(this_id, 0) + exon_length
+    records = _read_annotation_records(gtf_path, file_type)
+    # map each transcript/mRNA to its parent gene (dict assignment -> last-wins on duplicate ids)
+    transcript_rows = records.filter(pl.col('feature').is_in(('transcript', 'mRNA')))
+    transcripts_to_genes = dict(zip(transcript_rows['_transcript'].to_list(), transcript_rows['_gene'].to_list()))
+    exons = records.filter(pl.col('feature') == 'exon').with_columns(
+        (pl.col('end') - pl.col('start') + 1).alias('_length'))
 
     if feature_type == 'transcript':
         warnings.warn("Since feature_type='transcript', the method parameter is ignored. ")
-        return transcript_lengths
+        return _sum_exon_lengths_per_parent(exons)
 
-    elif method == 'merged_exons':
-        # if the method is 'merged_exons', sum the intervals of the exons for each gene.
-        # No need to map to transcripts since it was done earlier.
-        summed_gene_lengths = dict()
-        for gene_id, intervals in transcript_lengths.items():
-            summed_gene_lengths[gene_id] = generic.sum_intervals_inclusive(intervals)
-        return summed_gene_lengths
+    if method == 'merged_exons':
+        # attribute each exon to the FIRST parent transcript's gene, then union the exon intervals per gene
+        gene_intervals = {}
+        for parents, start, end in exons.select('_parents', 'start', 'end').iter_rows():
+            gene_id = transcripts_to_genes[parents[0]]
+            gene_intervals.setdefault(gene_id, []).append((start, end))
+        return {gene_id: generic.sum_intervals_inclusive(intervals)
+                for gene_id, intervals in gene_intervals.items()}
 
-    # map transcripts to genes
+    # average the per-transcript lengths within each gene, per the chosen method
+    transcript_lengths = _sum_exon_lengths_per_parent(exons)
     gene_lengths = {}
-    for transcript_ids, gene_id in transcripts_to_genes.items():
-        if gene_id not in gene_lengths:
-            gene_lengths[gene_id] = []
-        gene_lengths[gene_id].append(transcript_lengths[transcript_ids])
+    for transcript, gene_id in transcripts_to_genes.items():
+        gene_lengths.setdefault(gene_id, []).append(transcript_lengths[transcript])
 
-    # average transcript lengths per gene according to the specified function (method)
-    avg_gene_lengths = {}
     avg_func = method_funcs[method]
+    avg_gene_lengths = {}
     for gene in gene_lengths:
         if len(gene_lengths[gene]) == 1:
             avg_gene_lengths[gene] = gene_lengths[gene][0]
         else:
             avg_gene_lengths[gene] = avg_func(gene_lengths[gene])
-
     return avg_gene_lengths
 
 
@@ -127,47 +223,58 @@ def map_gene_to_attr(gtf_path: Union[str, Path], attribute: str, feature_type: s
     validation.validate_genome_annotation_file(gtf_path, accept_gff3=False)
     assert feature_type in {'gene', 'transcript'}, f"Invalid feature_type: '{feature_type}'"
 
+    # extract everything the (bug-for-bug) reduction below reads, one row per line, in file order
+    rows = _scan_annotation_lines(gtf_path).filter(pl.col('_n') == _N_COLUMNS).with_columns(
+        pl.col('_fields').list.get(_ATTR_IDX).alias('_attr')).select(
+        _extract_gtf_attribute(pl.col('_attr'), attribute).alias('attr_value'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_id').alias('gene_id'),
+        _extract_gtf_attribute(pl.col('_attr'), 'transcript_id').alias('transcript_id'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_version').alias('gene_version'),
+        _extract_gtf_attribute(pl.col('_attr'), 'transcript_version').alias('transcript_version'),
+        _extract_gtf_attribute(pl.col('_attr'), 'gene_name').alias('gene_name'),
+        _extract_gtf_attribute(pl.col('_attr'), 'transcript_name').alias('transcript_name'),
+        _extract_gtf_attribute(pl.col('_attr'), 'name').alias('name'),
+    ).collect()
+
     mapping = {}
-    with open(gtf_path, errors="ignore") as f:
-        for line in f.readlines():
-            if len(line) == 0 or line[0] == '#':
-                continue
-            line_split = line.strip().split('\t')
-            attributes = line_split[8]
-            attributes_dict = parsing.parse_gtf_attributes(attributes)
-            if attribute not in attributes_dict:
-                continue
+    for row in rows.iter_rows(named=True):
+        if row['attr_value'] is None:  # this line does not carry the requested attribute
+            continue
+        feature_name = None
+        if feature_type == 'gene':
+            if row['gene_id'] is None:
+                raise KeyError('gene_id')
+            feature_id = row['gene_id'].split('.')[0] if split_ids else row['gene_id']
+            if use_version:
+                if row['gene_version'] is None:
+                    raise KeyError('gene_version')
+                feature_id += '.' + row['gene_version']
+            if use_name:
+                if row['gene_name'] is not None:
+                    feature_name = row['gene_name']
+                elif row['name'] is not None:
+                    feature_name = row['name']
+                else:
+                    continue
+        else:
+            if row['transcript_id'] is None:
+                raise KeyError('transcript_id')
+            feature_id = row['transcript_id'].split('.')[0] if split_ids else row['transcript_id']
+            if use_version:
+                if row['transcript_version'] is None:
+                    raise KeyError('transcript_version')
+                feature_id += '.' + row['transcript_version']
+            if use_name:
+                # BUG #1 (to be fixed in #152): gated on gene_name but the value read is transcript_name
+                if row['gene_name'] is not None:
+                    feature_name = row['transcript_name']
+                elif row['name'] is not None:
+                    feature_name = row['name']
+                else:
+                    continue
 
-            feature_name = None
-            if feature_type == 'gene':
-                feature_id = attributes_dict['gene_id'].split(".")[0] if split_ids else attributes_dict['gene_id']
-                if use_version:
-                    feature_id += '.' + attributes_dict['gene_version']
-
-                if use_name:
-                    if 'gene_name' in attributes_dict:
-                        feature_name = attributes_dict['gene_name']
-                    elif 'name' in attributes_dict:
-                        feature_name = attributes_dict['name']
-                    else:
-                        continue
-
-            else:
-                feature_id = attributes_dict['transcript_id'].split(".")[0] if split_ids else attributes_dict[
-                    'transcript_id']
-                if use_version:
-                    feature_id += '.' + attributes_dict['transcript_version']
-
-                if use_name:
-                    if 'gene_name' in attributes_dict:
-                        feature_name = attributes_dict['transcript_name']
-                    elif 'name' in attributes_dict:
-                        feature_name = attributes_dict['name']
-                    else:
-                        continue
-
-            if feature_id in mapping:
-                continue
-            mapping[feature_name if use_name else feature_id] = attributes_dict[attribute]
+        if feature_id in mapping:
+            continue
+        mapping[feature_name if use_name else feature_id] = row['attr_value']
 
     return mapping

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -312,33 +312,17 @@ def parse_version(version: str):
     return [int(i) for i in split]
 
 
+# parse_gtf_attributes / parse_gff3_attributes now live in utils.genome_annotation (the single home for all
+# GTF/GFF parsing). These thin shims preserve backwards compatibility for direct importers; the import is
+# deferred to call time to avoid a circular import (genome_annotation imports from this module).
 def parse_gtf_attributes(attr_str: str):
-    attributes_dict = {}
-    for this_attr in attr_str.split('; '):
-        this_attr = this_attr.strip()
-        key_end = this_attr.find(' ')
-        if key_end == -1:
-            continue
-        key = this_attr[:key_end]
-        val_start = this_attr.find('"', key_end)
-        val_end = this_attr.find('"', val_start + 1)
-        val = this_attr[val_start + 1:val_end]
-        attributes_dict[key] = val
-    return attributes_dict
+    from rnalysis.utils import genome_annotation
+    return genome_annotation.parse_gtf_attributes(attr_str)
 
 
 def parse_gff3_attributes(attr_str: str):
-    attributes_dict = {}
-    for this_attr in attr_str.rstrip().split(';'):
-        this_attr = this_attr.strip()
-        if len(this_attr) == 0:
-            continue
-        key, val = this_attr.split('=')
-        val = val.split(',')
-        if len(val) == 1:
-            val = val[0]
-        attributes_dict[key] = val
-    return attributes_dict
+    from rnalysis.utils import genome_annotation
+    return genome_annotation.parse_gff3_attributes(attr_str)
 
 
 def format_dict_for_display(d: dict) -> str:

--- a/tests/test_docs_user_guide_examples.py
+++ b/tests/test_docs_user_guide_examples.py
@@ -7,8 +7,11 @@ GUI_GUIDE = DOCS_DIR / 'user_guide_gui.rst'
 
 
 def test_user_guide_examples_use_current_api_names_and_paths():
-    user_guide = USER_GUIDE.read_text()
-    gui_guide = GUI_GUIDE.read_text()
+    # The guides contain non-ASCII characters (e.g. Polars table-repr box-drawing glyphs), so the
+    # encoding must be pinned to UTF-8 -- otherwise read_text() uses the platform default (cp1252 on
+    # Windows), which fails to decode them and breaks this test on Windows only.
+    user_guide = USER_GUIDE.read_text(encoding='utf-8')
+    gui_guide = GUI_GUIDE.read_text(encoding='utf-8')
 
     assert 'normalize_quantile' not in user_guide
     assert 'normalize_quantile' not in gui_guide

--- a/tests/test_genome_annotation.py
+++ b/tests/test_genome_annotation.py
@@ -307,3 +307,31 @@ def test_map_gene_to_attr_use_version_keyerror(feature_type, attribute, missing_
     # BUG #2 (fix in #152): use_version unconditionally reads *_version, so a file without those attrs raises KeyError.
     with pytest.raises(KeyError, match=missing_key):
         map_gene_to_attr(GENCODE_GTF, attribute, feature_type, False, True, False)
+
+
+# ------------------------------------------------------------------ anchored-key regex (PR-B, #151, item #3)
+# The Polars rewrite extracts attributes with an anchored regex so a key is never matched inside a longer
+# compound key (e.g. gene_id must not be read from havana_gene_id). These are the tripwire for that: a naive
+# unanchored pattern would capture the WRONG value below.
+def _compound_key_gtf(tmp_path):
+    pth = tmp_path / 'compound.gtf'
+    pth.write_text(
+        '1\thavana\tgene\t100\t200\t.\t+\t.\t'
+        'havana_gene_id "WRONGGENE"; gene_id "RIGHTGENE"; gene_name "GENEA";\n'
+        '1\thavana\ttranscript\t100\t200\t.\t+\t.\t'
+        'havana_gene_id "WRONGGENE"; gene_id "RIGHTGENE"; '
+        'havana_transcript_id "WRONGTX"; transcript_id "RIGHTTX"; gene_name "GENEA";\n',
+        encoding='utf-8', newline='\n')
+    return pth
+
+
+def test_map_transcripts_to_genes_anchored_key_ignores_compound_key(tmp_path):
+    # gene_id / transcript_id must come from the real keys, not havana_gene_id / havana_transcript_id.
+    assert map_transcripts_to_genes(_compound_key_gtf(tmp_path), use_version=False, split_ids=False) == {
+        'RIGHTTX': 'RIGHTGENE'}
+
+
+def test_map_gene_to_attr_anchored_key_ignores_compound_key(tmp_path):
+    # Same guarantee via the map_gene_to_attr extraction path: the gene id key is RIGHTGENE, not WRONGGENE.
+    assert map_gene_to_attr(_compound_key_gtf(tmp_path), 'gene_name', 'gene', False, False, False) == {
+        'RIGHTGENE': 'GENEA'}


### PR DESCRIPTION
## What & why

**PR-B of epic #67** (Polars-native genome-annotation module). Closes #151.

Consolidates all GTF/GFF parsing into `rnalysis/utils/genome_annotation.py` and swaps the internals to a Polars-native pipeline, holding outputs **byte-identical** to the previous implementation — guarded by the #150 characterization tests (now on `development`). This is the behaviour-preserving refactor; the robustness/bugfix work (bugs #1/#2, GFF3 parity, gzip, alias resolution) stays deferred to PR-C (#152).

## What's in it

- **Consolidation** — moved `parse_gtf_attributes` / `parse_gff3_attributes` into the annotation module (their only real home); lazy re-export shims remain in `utils/parsing.py`, so direct importers keep working with no circular import and `test_parsing` is untouched.
- **Polars-native parse** — `pl.scan_csv` reads one row per line and attribute values are pulled out column-wise with anchored regexes, with the two must-not-regress corrections:
  - **#3 anchored key** — the key is anchored on a start-of-string / `;` boundary, so `gene_id` is never captured from a compound key like `havana_gene_id` (a naive pattern grabs the wrong value). Two new regression tests are the tripwire.
  - **#4 GFF3 multi-value** — comma-separated `Parent=a,b` is preserved and a shared exon is attributed to **each** parent transcript.
  - `seqname` stays `pl.String` (RNAlysis is cross-organism; no human-chromosome `Enum`).
- **Faithful reductions** — geometric_mean via scipy `gmean`, merged-exon interval union via `generic.sum_intervals_inclusive`, first-wins dedup, and the `len==1` special case are all reproduced exactly, as are the two pinned bugs (#1 `transcript_name` read under a `gene_name` gate; #2 `KeyError` on absent `*_version`) — fixed later in #152.
- **Malformed lines** — the divergent handling is reproduced exactly: `map_transcripts_to_genes` **raises** `ValueError('Invalid GTF format …')`, `get_genomic_feature_lengths` **silently skips**. The raise now names the offending line, which the old message did too.
- `.explode(empty_as_null=…)` is set explicitly to silence the Polars 1.x deprecation and pin behaviour across the 2.0 default change.

## Verification

- `pytest tests/test_genome_annotation.py tests/test_parsing.py` → **202 passed** locally (no R / Qt / network). Every characterization assertion passes **unchanged**; the 2 new anchored-key tests are added on top.
- Downstream integration, un-mocked: `pytest tests/test_filtering.py -k "biotype or rpkm or tpm"` → **67 passed** (`filter_biotype_from_gtf` / `biotypes_from_gtf` exercise `map_gene_to_attr` for real, on a fixture outside the characterization corpus).
- An independent clean-context review found **no correctness regressions on well-formed or corpus input**; the only divergences are on malformed / non-standard lines, where the new code is equal-or-more-robust than the original. Two touch-ups from that review are folded in: the offending line is named in the error message, and the extractor's first-occurrence semantics are documented.

## Compatibility

No public-API or serialized-format change — signatures and dict return types are unchanged. Outputs are identical, so there is **no** `HISTORY.rst` numerical-change entry.

## Note on the base

PR-A (#150 / #162) is already merged into `development`, so this PR targets `development` directly rather than stacking. It also **includes the #163 doc-test fix** (cherry-picked) so the Windows CI job is green; that commit becomes a no-op once #163 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
