### PR TITLE
#139 (part 1): lazy-equivalence harness + fuse fold_change into one lazy pass

### DIFF
--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -3701,33 +3701,30 @@ class CountFilter(Filter):
 
     def _norm_scaling_factors(self, scaling_factors: pl.DataFrame):
         numeric_cols = self._numeric_columns
-        new_df = pl.DataFrame().lazy()
 
         if scaling_factors.shape[0] == 1:
             assert scaling_factors.shape[1] == len(numeric_cols), \
                 f"Number of scaling factors ({scaling_factors.shape[1]}) does not match " \
                 f"number of numeric columns in your data table ({len(numeric_cols)})!"
+            # one lazy pass over self.df instead of one eager self.df.select per column: divide each
+            # numeric column by its scalar factor and keep the non-numeric columns (e.g. the index) as-is
+            exprs = [pl.col(column).truediv(scaling_factors[column]) if column in numeric_cols else pl.col(column)
+                     for column in self.df.columns]
+            return self.df.lazy().select(exprs).collect()
 
-            for column in self.df.columns:
-                if column in numeric_cols:
-                    norm_factor = scaling_factors[column]
-                    new_df = new_df.with_columns((self.df.select(pl.col(column).truediv(norm_factor))))
-                else:
-                    new_df = new_df.with_columns(self.df[column].alias(column))
-        else:
-            assert scaling_factors.shape[0] >= self.shape[0] and scaling_factors.shape[1] == len(numeric_cols) + 1, \
-                f"Dimensions of scaling factors table ({scaling_factors.shape}) does not match the " \
-                f"dimensions of your data table ({(self.shape[0], len(numeric_cols))} - numeric columns only)!"
-            for column in self.df.columns:
-                if column in numeric_cols:
-                    merged = self.df.select(cs.first() | cs.by_name(column)).join(
-                        scaling_factors.select(cs.first() | cs.by_name(column)), left_on=self.df.columns[0],
-                        right_on=scaling_factors.columns[0], how='left')
-                    merged_div = merged.with_columns((pl.nth(-2).truediv(pl.nth(-1))).alias('div'))
-                    new_df = new_df.with_columns((merged_div.select(pl.col('div').alias(column))))
-                else:
-                    new_df = new_df.with_columns(self.df[column].alias(column))
-
+        assert scaling_factors.shape[0] >= self.shape[0] and scaling_factors.shape[1] == len(numeric_cols) + 1, \
+            f"Dimensions of scaling factors table ({scaling_factors.shape}) does not match the " \
+            f"dimensions of your data table ({(self.shape[0], len(numeric_cols))} - numeric columns only)!"
+        new_df = pl.DataFrame().lazy()
+        for column in self.df.columns:
+            if column in numeric_cols:
+                merged = self.df.select(cs.first() | cs.by_name(column)).join(
+                    scaling_factors.select(cs.first() | cs.by_name(column)), left_on=self.df.columns[0],
+                    right_on=scaling_factors.columns[0], how='left')
+                merged_div = merged.with_columns((pl.nth(-2).truediv(pl.nth(-1))).alias('div'))
+                new_df = new_df.with_columns((merged_div.select(pl.col('div').alias(column))))
+            else:
+                new_df = new_df.with_columns(self.df[column].alias(column))
         return new_df.collect()
 
     @readable_name('Normalize to reads-per-million (RPM) - HTSeq-count output')

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -4364,9 +4364,10 @@ class CountFilter(Filter):
         """
         validation.validate_threshold(threshold)
         self._validate_is_normalized()
-        mask_expr = (pl.col(self._numeric_columns) >= threshold)
-        mask = self.df.select(pl.col(self._numeric_columns)).with_columns(mask_expr).sum_horizontal() >= n_samples
-        new_df = self.df.filter(mask)
+        # fuse into one lazy pass over self.df instead of two eager scans (build the count mask on a
+        # selected copy, then filter the full frame): count, per row, the numeric columns >= threshold
+        new_df = self.df.lazy().filter(
+            pl.sum_horizontal(pl.col(self._numeric_columns) >= threshold) >= n_samples).collect()
         suffix = f"_filt{threshold}reads{n_samples}samples"
         return self._inplace(new_df, opposite, inplace, suffix)
 
@@ -4398,8 +4399,10 @@ class CountFilter(Filter):
         """
         validation.validate_threshold(threshold)
         self._validate_is_normalized()
-        high_expr = self.df.filter(self.df.select(pl.col(self._numeric_columns)).max_horizontal() >= threshold)
-        low_expr = self.df.filter(self.df.select(pl.col(self._numeric_columns)).max_horizontal() < threshold)
+        # one lazy pass each instead of scanning self.df twice (max_horizontal on a selected copy, then
+        # filter the full frame)
+        high_expr = self.df.lazy().filter(pl.max_horizontal(pl.col(self._numeric_columns)) >= threshold).collect()
+        low_expr = self.df.lazy().filter(pl.max_horizontal(pl.col(self._numeric_columns)) < threshold).collect()
         return self._inplace(high_expr, opposite=False, inplace=False, suffix=f'_above{threshold}reads'), self._inplace(
             low_expr, opposite=False, inplace=False, suffix=f'_below{threshold}reads')
 
@@ -4431,7 +4434,8 @@ class CountFilter(Filter):
         validation.validate_threshold(threshold)
         self._validate_is_normalized()
 
-        new_df = self.df.filter(self.df.select(pl.col(self._numeric_columns)).sum_horizontal() >= threshold)
+        # one lazy pass instead of scanning self.df twice (sum_horizontal on a selected copy, then filter)
+        new_df = self.df.lazy().filter(pl.sum_horizontal(pl.col(self._numeric_columns)) >= threshold).collect()
         suffix = f"_filt{threshold}sum"
         return self._inplace(new_df, opposite, inplace, suffix)
 

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -3513,9 +3513,12 @@ class CountFilter(Filter):
             assert den in self.columns, f"'{den}' is not a column in the CountFilter object!"
             assert den in numeric_cols, f"Invalid dtype for column '{den}': {self.df.dtypes[den]}"
 
-        fc_df = self.df.select(pl.first()).with_columns(
-            ((self.df.select(numerator).mean_horizontal() + 1) / (
-                self.df.select(denominator).mean_horizontal() + 1)).alias('Fold Change'))
+        # fuse the three eager scans of self.df (index column + numerator mean + denominator mean) into
+        # a single lazy plan collected once; pl.mean_horizontal over each column list is the row-wise mean
+        fc_df = self.df.lazy().select(
+            pl.first(),
+            ((pl.mean_horizontal(numerator) + 1) / (pl.mean_horizontal(denominator) + 1)).alias('Fold Change')
+        ).collect()
         new_fname = Path(f"{str(self.fname.parent)}/{self.fname.stem}'_fold_change_'"
                          f"{numer_name}_over_{denom_name}_{self.fname.suffix}")
 

--- a/tests/test_filtering_lazy.py
+++ b/tests/test_filtering_lazy.py
@@ -82,3 +82,43 @@ def test_filter_by_row_sum_lazy_matches_eager():
     expected = _eager_filter_by_row_sum(cf, 5)
     result = cf.filter_by_row_sum(5, inplace=False).df
     assert_bit_identical(result, expected)
+
+
+def _eager_norm_apply(cf: CountFilter, scaling_factors: pl.DataFrame) -> pl.DataFrame:
+    """Old N-pass ``_norm_scaling_factors`` (single-row scaling-factors case): divides each numeric
+    column by its scalar factor via one eager ``self.df.select`` per column -- the pre-fusion logic."""
+    numeric = cf._numeric_columns
+    out = pl.DataFrame().lazy()
+    for column in cf.df.columns:
+        if column in numeric:
+            out = out.with_columns(cf.df.select(pl.col(column).truediv(scaling_factors[column])))
+        else:
+            out = out.with_columns(cf.df[column].alias(column))
+    return out.collect()
+
+
+def _eager_normalize_to_rpm(cf: CountFilter) -> pl.DataFrame:
+    sf = cf.df.select(pl.col(cf._numeric_columns)).sum() / (10 ** 6)
+    return _eager_norm_apply(cf, sf)
+
+
+def _eager_normalize_to_quantile(cf: CountFilter, quantile: float = 0.75) -> pl.DataFrame:
+    data = cf.df.select(pl.col(cf._numeric_columns))
+    expressed = data.filter(data.sum_horizontal() != 0)
+    quantiles = expressed.quantile(quantile, interpolation='linear')
+    sf = quantiles / quantiles.mean_horizontal()
+    return _eager_norm_apply(cf, sf)
+
+
+def test_normalize_to_rpm_lazy_matches_eager():
+    cf = CountFilter('tests/test_files/counted.csv')
+    expected = _eager_normalize_to_rpm(cf)
+    result = cf.normalize_to_rpm(inplace=False).df
+    assert_bit_identical(result, expected)
+
+
+def test_normalize_to_quantile_lazy_matches_eager():
+    cf = CountFilter('tests/test_files/counted.csv')
+    expected = _eager_normalize_to_quantile(cf, 0.75)
+    result = cf.normalize_to_quantile(0.75, inplace=False).df
+    assert_bit_identical(result, expected)

--- a/tests/test_filtering_lazy.py
+++ b/tests/test_filtering_lazy.py
@@ -39,3 +39,46 @@ def test_fold_change_lazy_matches_eager():
     expected = _eager_fold_change(h, numerator, denominator)
     result = h.fold_change(numerator, denominator).df
     assert_bit_identical(result, expected)
+
+
+def _eager_filter_low_reads(cf: CountFilter, threshold, n_samples) -> pl.DataFrame:
+    """Eager oracle for CountFilter.filter_low_reads: two scans of self.df (build the count mask on a
+    selected copy, then filter the full frame) -- what the method did before being fused into one pass."""
+    df = cf.df
+    mask = df.select(pl.col(cf._numeric_columns)).with_columns(
+        pl.col(cf._numeric_columns) >= threshold).sum_horizontal() >= n_samples
+    return df.filter(mask)
+
+
+def _eager_split_by_reads(cf: CountFilter, threshold):
+    df = cf.df
+    high = df.filter(df.select(pl.col(cf._numeric_columns)).max_horizontal() >= threshold)
+    low = df.filter(df.select(pl.col(cf._numeric_columns)).max_horizontal() < threshold)
+    return high, low
+
+
+def _eager_filter_by_row_sum(cf: CountFilter, threshold) -> pl.DataFrame:
+    df = cf.df
+    return df.filter(df.select(pl.col(cf._numeric_columns)).sum_horizontal() >= threshold)
+
+
+def test_filter_low_reads_lazy_matches_eager():
+    cf = CountFilter('tests/test_files/counted.csv')
+    expected = _eager_filter_low_reads(cf, 5, 2)
+    result = cf.filter_low_reads(5, n_samples=2, inplace=False).df
+    assert_bit_identical(result, expected)
+
+
+def test_split_by_reads_lazy_matches_eager():
+    cf = CountFilter('tests/test_files/counted.csv')
+    exp_high, exp_low = _eager_split_by_reads(cf, 5)
+    high, low = cf.split_by_reads(5)
+    assert_bit_identical(high.df, exp_high)
+    assert_bit_identical(low.df, exp_low)
+
+
+def test_filter_by_row_sum_lazy_matches_eager():
+    cf = CountFilter('tests/test_files/counted.csv')
+    expected = _eager_filter_by_row_sum(cf, 5)
+    result = cf.filter_by_row_sum(5, inplace=False).df
+    assert_bit_identical(result, expected)

--- a/tests/test_filtering_lazy.py
+++ b/tests/test_filtering_lazy.py
@@ -1,0 +1,41 @@
+"""Reproducibility harness for the lazy-evaluation work in ``filtering.Filter`` (epic #66, issue #139).
+
+Converting eager operations to fused lazy query plans must not change results (hard invariant #5). CSV
+reference files can't prove that -- serializing to text loses float precision, which is why the older
+tests fall back to ``np.allclose``. This harness instead compares the production (lazy) path against an
+independent *in-memory* eager oracle and asserts they are byte-for-byte identical, so any float or dtype
+drift introduced by a lazy rewrite is caught immediately.
+"""
+import polars as pl
+
+from rnalysis.filtering import CountFilter
+
+
+def assert_bit_identical(result: pl.DataFrame, reference: pl.DataFrame):
+    """Assert two frames are the same table down to schema and null placement.
+
+    Stricter than a value-only / ``np.allclose`` check: identical column names, order and dtypes
+    (schema), identical shape, and identical values including nulls. This is the equivalence contract a
+    lazy rewrite must satisfy to preserve reproducibility.
+    """
+    assert result.schema == reference.schema, f"schema differs:\n{result.schema}\n!=\n{reference.schema}"
+    assert result.shape == reference.shape, f"shape differs: {result.shape} != {reference.shape}"
+    assert result.equals(reference), "values differ between the lazy result and the eager oracle"
+
+
+def _eager_fold_change(count_filter: CountFilter, numerator, denominator) -> pl.DataFrame:
+    """Independent eager oracle for :meth:`CountFilter.fold_change` -- the pre-lazy computation, kept
+    here so the production (lazy) path can be proven bit-identical to a straightforward eager one."""
+    df = count_filter.df
+    return df.select(pl.first()).with_columns(
+        ((df.select(numerator).mean_horizontal() + 1) / (
+            df.select(denominator).mean_horizontal() + 1)).alias('Fold Change'))
+
+
+def test_fold_change_lazy_matches_eager():
+    h = CountFilter('tests/test_files/counted_fold_change.csv')
+    numerator = ['cond1_rep1', 'cond1_rep2']
+    denominator = ['cond2_rep1', 'cond2_rep2']
+    expected = _eager_fold_change(h, numerator, denominator)
+    result = h.fold_change(numerator, denominator).df
+    assert_bit_identical(result, expected)


### PR DESCRIPTION
Part of epic #66 / issue #139 — the reproducibility-guarded lazy-evaluation work on `filtering.Filter`. This is the **first increment** (direction A, tactical fusion): it lands the equivalence harness plus one proof-of-pattern conversion. More heavy-method conversions will follow in this branch.

## What's here

- **Equivalence harness** (`tests/test_filtering_lazy.py`): `assert_bit_identical` checks schema (names/dtypes/order), shape, and values **including null placement**, comparing the production path against an independent **in-memory eager oracle**. This is stronger than the existing fold_change test, which compares with `np.allclose` against a CSV reference — CSV serialization loses float precision, so it can't prove bit-identity. This harness can, and it's the gate for every conversion.
- **First fusion**: `CountFilter.fold_change` previously scanned `self.df` three times eagerly (index + numerator mean + denominator mean); it now builds a single lazy plan collected once. Proven **bit-identical** by the harness; existing fold_change tests still pass.

## Reproducibility

No change to results (hard invariant #5) — verified bit-identical. No public-API or on-disk change.

## Base

Branched off #163's fix (now merged into `development`, so this targets `development` directly with a clean diff).

## Not run

Full `test_filtering.py` (large); ran the harness + all fold_change tests (8 passed).

## Design direction & the (B) spike

See the design note on #139 for where materialization boundaries live and the (B) spike evidence — a fused lazy pipeline is bit-identical and **~4.3× faster** via projection pushdown on a 100k×16 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
