### PR TITLE
perf(clustering): vectorize CLICOM find_cliques with numpy bitsets (#126)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Changed
 *******
 * Updated the required ``polars`` version to 1.43.x (from 1.41.x). Analysis results are unchanged; this was verified against the RNAlysis test suite.
 * CLICOM ensemble clustering (``CountFilter.split_clicom``) now runs faster, by computing each distinct power-transform/standardization of the data only once per run and reusing it across the many clustering setups that share it, instead of recomputing the identical transform for every setup. Clustering results are bit-for-bit identical.
+* CLICOM's clique-finding step (the second-slowest part of ``CountFilter.split_clicom``) now runs up to tens of times faster, by replacing its cubic pure-Python loop over sets with a vectorized NumPy bitset implementation. Clustering results are bit-for-bit identical.
 * The Principal Component Analysis functions (``pca``, ``sort_by_principal_component``, and ``split_by_principal_components``) now run substantially faster on large datasets, by parallelizing the per-gene Box-Cox power transform across CPU cores. Results are unchanged up to floating-point precision (verified against the test suite's reference outputs).
 * Ensembl ortholog and paralog mapping now caches each gene's homology results in the daily cache, so repeating a mapping (or mapping gene sets that overlap a previous one) no longer re-requests the same data from Ensembl. This reduces load on the Ensembl REST API and speeds up repeated mappings.
 

--- a/rnalysis/utils/clustering.py
+++ b/rnalysis/utils/clustering.py
@@ -125,6 +125,9 @@ class ArbitraryClusterer(abc.ABC):
 
 
 class CLICOM:
+    # cap on find_cliques' per-block working set (bytes); keeps the packed-bitset matrix bounded for large graphs
+    _MAX_CLIQUE_BLOCK_BYTES = 32 * 1024 * 1024
+
     def __init__(self, clustering_solutions: BinaryFormatClusters, threshold: float, cluster_wise_cliques: bool = True,
                  cluster_unclustered_features: bool = True, min_cluster_size: int = 15, parallel_backend='loky'):
         self.clustering_solutions: BinaryFormatClusters = clustering_solutions
@@ -172,10 +175,8 @@ class CLICOM:
         # test_find_cliques_matches_reference). Because each K_ij evolves independently of the
         # others, we process only the strict-upper-triangle cells that carry an edge, in
         # memory-bounded blocks, rather than materialising the full n*n object matrix.
-        binary_mat = self.binary_mat
-        if hasattr(binary_mat, 'to_numpy'):  # accept a polars/pandas frame as well as an ndarray
-            binary_mat = binary_mat.to_numpy()
-        binary_mat = np.asarray(binary_mat, dtype=bool)
+        # binary_mat is normally an ndarray; np.asarray also accepts the polars frame the unit tests inject
+        binary_mat = np.asarray(self.binary_mat, dtype=bool)
         n_objs = binary_mat.shape[0]
         n_words = (n_objs + 63) // 64
 
@@ -196,9 +197,8 @@ class CLICOM:
         if n_cells == 0:
             return
 
-        # cap each block's working set (b * n_words uint64 words) at ~32 MB of RAM
-        max_block_bytes = 32 * 1024 * 1024
-        block = max(1, min(n_cells, max_block_bytes // (8 * n_words)))
+        # cap each block's working set (b * n_words uint64 words) to bound memory on large graphs
+        block = max(1, min(n_cells, self._MAX_CLIQUE_BLOCK_BYTES // (8 * n_words)))
         n_blocks = (n_cells + block - 1) // block
 
         with tqdm(total=n_objs * n_blocks, desc='Finding cliques') as pbar:

--- a/rnalysis/utils/clustering.py
+++ b/rnalysis/utils/clustering.py
@@ -164,38 +164,86 @@ class CLICOM:
         return labels
 
     def find_cliques(self):
-        # fast_cliquer algorithm:
-        n_objs = self.binary_mat.shape[0]
-        # build K0
-        clique_mat = np.zeros_like(self.adj_mat, dtype='object')
-        for i in range(n_objs):
-            for j in range(n_objs):
-                if self.binary_mat[i, j]:
-                    clique_mat[i, j] = {i, j}
-                else:
-                    clique_mat[i, j] = set()
-        # create neighbors set
-        neighbor_sets = [set() for _ in range(n_objs)]
-        for i in range(n_objs):
-            for j in range(n_objs):
-                if self.binary_mat[i, j] and i != j:
-                    neighbor_sets[i].add(j)
+        # fast_cliquer algorithm, accelerated with numpy uint64 bitsets (issue #126).
+        # Each K_ij clique and each pivot's neighbour set is stored as a packed bit-array
+        # (W = ceil(n / 64) uint64 words, one bit per object), so the O(n^3) subset test and
+        # membership update become vectorised word-wise operations instead of Python set ops.
+        # The result is identical to the original set-based implementation (see
+        # test_find_cliques_matches_reference). Because each K_ij evolves independently of the
+        # others, we process only the strict-upper-triangle cells that carry an edge, in
+        # memory-bounded blocks, rather than materialising the full n*n object matrix.
+        binary_mat = self.binary_mat
+        if hasattr(binary_mat, 'to_numpy'):  # accept a polars/pandas frame as well as an ndarray
+            binary_mat = binary_mat.to_numpy()
+        binary_mat = np.asarray(binary_mat, dtype=bool)
+        n_objs = binary_mat.shape[0]
+        n_words = (n_objs + 63) // 64
 
-        # sequentially construct K1..K|V|
-        with tqdm(total=n_objs ** 2, desc='Finding cliques') as pbar:
-            for pivot in range(n_objs):
-                for i in range(n_objs):
-                    for j in range(i, n_objs):
-                        # empty-set entries stay the same; if Kij(p-1) is subset of neighbors[p], add p to Kij(p-1)
-                        if len(clique_mat[i, j]) > 0 and clique_mat[i, j].issubset(neighbor_sets[pivot]):
-                            clique_mat[i, j].add(pivot)
+        # neighbours[p] packed as a bit-array of p's neighbours, excluding p itself
+        neighbors = binary_mat.copy()
+        np.fill_diagonal(neighbors, False)
+        not_neighbor_bits = ~self._pack_bit_rows(neighbors, n_words)  # (n_objs, n_words) uint64
+
+        # bit i lives in word (i // 64) at position (i % 64)
+        obj_word = np.arange(n_objs) // 64
+        obj_bit = np.uint64(1) << (np.arange(n_objs) % 64).astype(np.uint64)
+
+        # K0: only strict-upper-triangle cells carrying an edge can ever become a clique
+        row_idx, col_idx = np.triu_indices(n_objs, k=1)
+        has_edge = binary_mat[row_idx, col_idx]
+        row_idx, col_idx = row_idx[has_edge], col_idx[has_edge]
+        n_cells = row_idx.shape[0]
+        if n_cells == 0:
+            return
+
+        # cap each block's working set (b * n_words uint64 words) at ~32 MB of RAM
+        max_block_bytes = 32 * 1024 * 1024
+        block = max(1, min(n_cells, max_block_bytes // (8 * n_words)))
+        n_blocks = (n_cells + block - 1) // block
+
+        with tqdm(total=n_objs * n_blocks, desc='Finding cliques') as pbar:
+            for start in range(0, n_cells, block):
+                b_rows = row_idx[start:start + block]
+                b_cols = col_idx[start:start + block]
+                b = b_rows.shape[0]
+                # K0 for this block: each cell (i, j) starts as the clique {i, j}
+                cliques = np.zeros((b, n_words), dtype=np.uint64)
+                local = np.arange(b)
+                cliques[local, obj_word[b_rows]] |= obj_bit[b_rows]
+                cliques[local, obj_word[b_cols]] |= obj_bit[b_cols]
+                # sequentially construct K1..K|V|
+                for pivot in range(n_objs):
+                    # a clique gains the pivot iff it is a subset of the pivot's neighbours,
+                    # i.e. it contains no member that is a non-neighbour of the pivot
+                    not_subset = (cliques & not_neighbor_bits[pivot]).any(axis=1)
+                    cliques[~not_subset, obj_word[pivot]] |= obj_bit[pivot]
                     pbar.update(1)
+                # extract cliques with 2 or more members
+                for c in range(b):
+                    members = self._bits_to_members(cliques[c])
+                    if len(members) > 1:
+                        self.clique_set.add(frozenset(members))
 
-        # extract cliques
-        for i in range(self.binary_mat.shape[0]):
-            for j in range(i + 1, self.binary_mat.shape[0]):
-                if len(clique_mat[i, j]) > 1:  # only extract cliques with 2 or more members
-                    self.clique_set.add(frozenset(clique_mat[i, j]))
+    @staticmethod
+    def _pack_bit_rows(bool_mat: np.ndarray, n_words: int) -> np.ndarray:
+        """Pack each row of a boolean matrix into ``n_words`` uint64 words (bit j -> word j // 64, position j % 64)."""
+        packed = np.zeros((bool_mat.shape[0], n_words), dtype=np.uint64)
+        rows, cols = np.nonzero(bool_mat)
+        np.bitwise_or.at(packed, (rows, cols // 64), np.uint64(1) << (cols % 64).astype(np.uint64))
+        return packed
+
+    @staticmethod
+    def _bits_to_members(words: np.ndarray) -> List[int]:
+        """Return the sorted object indices whose bit is set in a packed uint64 bit-array."""
+        members = []
+        for word_idx in range(words.shape[0]):
+            w = int(words[word_idx])
+            base = word_idx * 64
+            while w:
+                lsb = w & (-w)
+                members.append(base + lsb.bit_length() - 1)
+                w ^= lsb
+        return members
 
     def cliques_to_clusters(self, allowed_overlap: float = 0.2) -> List[Set[int]]:
         sorted_cliques = [set(clique) for clique in

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -352,6 +352,38 @@ def test_find_cliques_matches_reference(n, density):
         assert clusterer.clique_set == expected
 
 
+@pytest.mark.parametrize('n,density', [(40, 0.2), (65, 0.2), (129, 0.15)])
+def test_find_cliques_matches_reference_multiblock(n, density, monkeypatch):
+    # force the memory-blocking path (one cell per block) so the multi-block loop is exercised,
+    # including across the 64-bit word boundary; the result must still equal the reference
+    monkeypatch.setattr(CLICOM, '_MAX_CLIQUE_BLOCK_BYTES', 1)
+    binary_mat = _random_symmetric_binary(n, density, 5)
+    expected = _reference_find_cliques(binary_mat)
+    clusterer = CLICOM.__new__(CLICOM)
+    clusterer.binary_mat = binary_mat
+    clusterer.clique_set = set()
+    clusterer.find_cliques()
+    assert clusterer.clique_set == expected
+
+
+def test_clicom_labels_match_reference(valid_clustering_solutions):
+    # end-to-end: the bitset find_cliques must yield the exact same labels_ as the original set-based
+    # algorithm (issue #126 spec: "same clique_set -> same final labels_"; hard invariant #5)
+    bin_format = BinaryFormatClusters(valid_clustering_solutions)
+    for cluster_wise in (True, False):
+        for threshold in (0.0, 1 / 3, 0.5, 1.01):
+            new = CLICOM(bin_format, threshold, cluster_wise_cliques=cluster_wise, min_cluster_size=1)
+            new.run()
+
+            reference = CLICOM(bin_format, threshold, cluster_wise_cliques=cluster_wise, min_cluster_size=1)
+            # drive run()'s unchanged downstream label pipeline from the ORIGINAL algorithm's clique_set
+            reference.find_cliques = lambda ref=reference: setattr(
+                ref, 'clique_set', _reference_find_cliques(np.asarray(ref.binary_mat, dtype=bool)))
+            reference.run()
+
+            assert np.array_equal(new.labels_, reference.labels_)
+
+
 def test_clicom_cluster_wise_result(valid_clustering_solutions):
     bin_format = BinaryFormatClusters(valid_clustering_solutions)
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -302,6 +302,56 @@ def test_find_cliques(monkeypatch):
     assert clicom.clique_set == truth
 
 
+def _reference_find_cliques(binary_mat):
+    """Exact copy of the original set-based fast_cliquer, kept as an equivalence oracle for issue #126.
+
+    ``find_cliques`` was rewritten to use numpy bitsets for speed; it must remain byte-for-byte
+    equivalent to this reference (hard invariant #5 — results must not change between versions)."""
+    n_objs = binary_mat.shape[0]
+    clique_mat = np.zeros_like(binary_mat, dtype='object')
+    for i in range(n_objs):
+        for j in range(n_objs):
+            clique_mat[i, j] = {i, j} if binary_mat[i, j] else set()
+    neighbor_sets = [set() for _ in range(n_objs)]
+    for i in range(n_objs):
+        for j in range(n_objs):
+            if binary_mat[i, j] and i != j:
+                neighbor_sets[i].add(j)
+    for pivot in range(n_objs):
+        for i in range(n_objs):
+            for j in range(i, n_objs):
+                if len(clique_mat[i, j]) > 0 and clique_mat[i, j].issubset(neighbor_sets[pivot]):
+                    clique_mat[i, j].add(pivot)
+    clique_set = set()
+    for i in range(n_objs):
+        for j in range(i + 1, n_objs):
+            if len(clique_mat[i, j]) > 1:
+                clique_set.add(frozenset(clique_mat[i, j]))
+    return clique_set
+
+
+def _random_symmetric_binary(n, density, seed):
+    rng = np.random.default_rng(seed)
+    upper = np.triu(rng.random((n, n)) < density, 1)
+    return upper | upper.T
+
+
+@pytest.mark.parametrize('n', [8, 16, 33, 64, 65, 100, 129])
+@pytest.mark.parametrize('density', [0.15, 0.35])
+def test_find_cliques_matches_reference(n, density):
+    # the bitset rewrite (#126) must reproduce the exact clique_set of the original set-based algorithm,
+    # including across the 64-bit word boundary (n = 64/65/129) that the packing must handle
+    for seed in range(2):
+        binary_mat = _random_symmetric_binary(n, density, seed)
+        expected = _reference_find_cliques(binary_mat)
+        clusterer = CLICOM.__new__(CLICOM)
+        clusterer.adj_mat = binary_mat.astype(float)
+        clusterer.binary_mat = binary_mat
+        clusterer.clique_set = set()
+        clusterer.find_cliques()
+        assert clusterer.clique_set == expected
+
+
 def test_clicom_cluster_wise_result(valid_clustering_solutions):
     bin_format = BinaryFormatClusters(valid_clustering_solutions)
 


### PR DESCRIPTION
## Summary

Closes #126. Rewrites `CLICOM.find_cliques` (`rnalysis/utils/clustering.py`) from an **O(n³) pure-Python triple loop over an object-array of Python `set`s** to a **vectorized numpy uint64 bitset** implementation — the second-largest contributor to `CountFilter.split_clicom` runtime after Box-Cox.

## Approach

- Each `K_ij` clique and each pivot's neighbour set is packed into `W = ⌈n/64⌉` uint64 words (one bit per object). The subset test becomes `(cliques & ~neighbours_p).any(axis=1)` and "add pivot to clique" becomes an OR of the pivot bit — vectorized across all cells for each pivot, replacing the Python `set.issubset`/`set.add` inner loop.
- **Key observation:** each `K_ij` evolves independently of the others (its trajectory depends only on its own `K0` and the fixed neighbour sequence). So we process only the strict-upper-triangle cells that carry an edge — the only ones ever extracted — through all pivots, in **RAM-bounded blocks**. This collapses the n³ Python loop to one vectorized pass per pivot and keeps memory bounded even in the large feature-wise mode.
- The `clique_set` remains `Set[frozenset]`, so `cliques_to_blocks` / `cliques_to_clusters` are untouched (the frozenset boundary the issue called out is preserved).

## Correctness — bit-for-bit identical output (hard invariant #5)

The output is identical to the original algorithm, verified by:

- **`test_find_cliques_matches_reference`** — a reference-oracle test that embeds the original set-based algorithm and asserts the new method reproduces its exact `clique_set` over random symmetric matrices across densities, including across the **64-bit word boundary** (n = 64/65/129).
- **`test_find_cliques_matches_reference_multiblock`** — forces one cell per block to exercise the memory-blocking path.
- **`test_clicom_labels_match_reference`** — end-to-end assertion that the new `find_cliques` yields the same `labels_` as the original algorithm (cluster-wise and feature-wise, across thresholds).
- The pre-existing fixture golden-master (`test_find_cliques`) and end-to-end result tests (`test_clicom_cluster_wise_result`, `test_clicom_feature_wise_result`) still pass unchanged.

All **65 tests** in `tests/test_clustering.py` pass locally.

## Performance

Measured on the real `find_cliques` method (random symmetric graphs, density 0.15):

| n | old (s) | new (s) | speedup |
|---|---|---|---|
| 150 | 0.108 | 0.014 | ~8× |
| 300 | 2.120 | 0.154 | ~14× |
| 400 | 7.984 | 0.339 | ~24× |
| 512 | 12.384 | 0.371 | ~33× |

~12× at density 0.35 — within the issue's 10–50× target. Results unchanged, so `HISTORY.rst` notes it as a pure performance improvement.

## Review

An independent clean-context review (Standards + Spec axes) ran on the diff; its findings were addressed in the second commit (explicit `labels_` equivalence test, multi-block coverage via a named block-size constant, and collapsing the redundant polars coercion).

## Not run locally

Full RNAlysis suite (no R / kallisto / bowtie2 in the local env). The change is confined to CLICOM's clique step; the entire `test_clustering.py` module passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpMANcLboWUkYH5QxC264U
