### PR TITLE
tests: cover DESeq2 $NORMFACTORS injection branch, remove stray debug print

### DIFF
--- a/rnalysis/utils/differential_expression.py
+++ b/rnalysis/utils/differential_expression.py
@@ -166,7 +166,6 @@ class DESeqRunner(DiffExpRunner):
             for lrt_factor in self.lrt_factors:
                 export_path = cache_dir.joinpath(f"DESeq2_{lrt_factor.replace(':', '_x_')}_LRT.csv").as_posix()
                 reduced_model = self.create_formula([lrt_factor])
-                print(reduced_model)
                 this_lrt = lrt_template.replace("$REDUCED", reduced_model)
                 this_lrt = this_lrt.replace("$OUTFILE_NAME", export_path).replace("$COOKS", cooks)
                 outfile.write(this_lrt)

--- a/tests/test_differential_expression.py
+++ b/tests/test_differential_expression.py
@@ -263,3 +263,47 @@ class TestDESeqRunner:
 
         expected = expected.replace('*PLACEHOLDERPATH*', out_path.parent.as_posix())
         assert out == expected
+
+    @pytest.mark.parametrize("data,design_matrix,comparisons,scale_factor_path,scale_factors_ndims,expected_path", [
+        ('tests/test_files/big_counted.csv', 'tests/test_files/test_design_matrix.csv',
+         [('condition', 'cond2', 'cond1')], 'tests/test_files/deseq2_tests/scaling_factors_1d.csv', 1,
+         'tests/test_files/deseq2_tests/case6/expected_deseq_script_normfactors_1d.R'),
+        ('tests/test_files/big_counted.csv', 'tests/test_files/test_design_matrix.csv',
+         [('condition', 'cond2', 'cond1')], 'tests/test_files/deseq2_tests/scaling_factors_2d.csv', 2,
+         'tests/test_files/deseq2_tests/case7/expected_deseq_script_normfactors_2d.R'),
+    ])
+    def test_create_deseq2_script_with_scale_factors(self, data, design_matrix, comparisons, scale_factor_path,
+                                                      scale_factors_ndims, expected_path):
+        runner = DESeqRunner(data, design_matrix, comparisons, scale_factor_path=scale_factor_path,
+                             scale_factors_ndims=scale_factors_ndims)
+        with open(expected_path) as f:
+            expected = f.read()
+
+        out_path = runner.create_script()
+        assert Path(out_path).exists()
+        with open(out_path) as f:
+            out = f.read()
+
+        expected = expected.replace('*PLACEHOLDERPATH*', out_path.parent.as_posix())
+        assert out == expected
+
+    @pytest.mark.parametrize("data,design_matrix,comparisons,expected_path", [
+        ('tests/test_files/big_counted.csv', 'tests/test_files/test_design_matrix.csv',
+         [('condition', 'cond2', 'cond1')],
+         'tests/test_files/deseq2_tests/case1/expected_deseq_script_1.R'),
+    ])
+    def test_create_deseq2_script_without_scale_factors_strips_normfactors_placeholder(
+            self, data, design_matrix, comparisons, expected_path):
+        # cooks_cutoff=False matches the golden file used by test_create_deseq2_script's case1
+        runner = DESeqRunner(data, design_matrix, comparisons, scale_factor_path=None, cooks_cutoff=False)
+        with open(expected_path) as f:
+            expected = f.read()
+
+        out_path = runner.create_script()
+        assert Path(out_path).exists()
+        with open(out_path) as f:
+            out = f.read()
+
+        assert '$NORMFACTORS' not in out
+        expected = expected.replace('*PLACEHOLDERPATH*', out_path.parent.as_posix())
+        assert out == expected

--- a/tests/test_files/deseq2_tests/case6/expected_deseq_script_normfactors_1d.R
+++ b/tests/test_files/deseq2_tests/case6/expected_deseq_script_normfactors_1d.R
@@ -1,0 +1,21 @@
+# Open a connection to a log file
+logfile <- file("*PLACEHOLDERPATH*/logfile.log", open = "a")
+# Redirect both output and messages to the file and console
+sink(logfile, append = TRUE, split = TRUE)
+
+require("DESeq2")
+
+count_data <- read.table("tests/test_files/big_counted.csv", header=TRUE, sep= ",", row.names = 1)
+design_matrix <- read.table("tests/test_files/test_design_matrix.csv", header=TRUE, sep= ",")
+dds <- DESeqDataSetFromMatrix(count_data, design_matrix, ~ condition + replicate)
+sizeFactors <- read.csv('tests/test_files/deseq2_tests/scaling_factors_1d.csv', row.names=1, header=TRUE)
+sizeFactors(dds) <- as.numeric(unlist(sizeFactors))
+
+dds_res <- DESeq(dds)
+res <- results(dds_res, contrast=c('condition', 'cond2', 'cond1'), cooksCutoff=TRUE)
+res_ordered <- res[order(res$padj),]
+write.csv(as.data.frame(res_ordered),file="*PLACEHOLDERPATH*/DESeq2_condition_cond2_vs_cond1.csv")
+# get session info
+sessionInfo()
+# Close the sink to stop redirecting output
+sink()

--- a/tests/test_files/deseq2_tests/case7/expected_deseq_script_normfactors_2d.R
+++ b/tests/test_files/deseq2_tests/case7/expected_deseq_script_normfactors_2d.R
@@ -1,0 +1,22 @@
+# Open a connection to a log file
+logfile <- file("*PLACEHOLDERPATH*/logfile.log", open = "a")
+# Redirect both output and messages to the file and console
+sink(logfile, append = TRUE, split = TRUE)
+
+require("DESeq2")
+
+count_data <- read.table("tests/test_files/big_counted.csv", header=TRUE, sep= ",", row.names = 1)
+design_matrix <- read.table("tests/test_files/test_design_matrix.csv", header=TRUE, sep= ",")
+dds <- DESeqDataSetFromMatrix(count_data, design_matrix, ~ condition + replicate)
+normFactors <- read.csv('tests/test_files/deseq2_tests/scaling_factors_2d.csv', row.names=1, header=TRUE)
+normFactors <- normFactors / exp(rowMeans(log(normFactors)))
+normalizationFactors(dds) <- data.matrix(normFactors)
+
+dds_res <- DESeq(dds)
+res <- results(dds_res, contrast=c('condition', 'cond2', 'cond1'), cooksCutoff=TRUE)
+res_ordered <- res[order(res$padj),]
+write.csv(as.data.frame(res_ordered),file="*PLACEHOLDERPATH*/DESeq2_condition_cond2_vs_cond1.csv")
+# get session info
+sessionInfo()
+# Close the sink to stop redirecting output
+sink()


### PR DESCRIPTION
Closes #173

## Summary

`DESeqRunner.create_script`'s `$NORMFACTORS` injection branch (feeding externally-supplied
normalization into DESeq2 via `scale_factor_path`) had no test coverage — no existing test
passed a `scale_factor_path`.

- Added `TestDESeqRunner.test_create_deseq2_script_with_scale_factors`, a golden-file test
  parametrized over `scale_factors_ndims=1` (emits `sizeFactors(dds) <- ...`) and
  `scale_factors_ndims=2` (emits `normalizationFactors(dds) <- ...` with geometric-mean
  centering), following the existing `test_create_deseq2_script*` pattern. New golden files:
  `tests/test_files/deseq2_tests/case6/expected_deseq_script_normfactors_1d.R` and
  `tests/test_files/deseq2_tests/case7/expected_deseq_script_normfactors_2d.R`.
- Added `TestDESeqRunner.test_create_deseq2_script_without_scale_factors_strips_normfactors_placeholder`,
  an explicit test confirming `scale_factor_path=None` strips the `$NORMFACTORS` placeholder
  (this was already implicitly covered by the pre-existing `case1`/etc. golden scripts, which
  contain no `$NORMFACTORS` line — this test makes the coverage explicit and asserts on it
  directly).
- Removed the stray `print(reduced_model)` debug line in the LRT branch of `create_script`
  (~L169). Confirmed no test reads stdout/uses `capsys`/depends on it.

## Test plan

- [x] `pytest tests/test_differential_expression.py -q -k "not test_run_deseq2_analysis and not test_run_limma_analysis"` — 22 passed locally (conda env `rnalysis`).
- [x] New tests only exercise `create_script()` (pure script-text generation, no R invoked).
- [ ] R-dependent integration tests (`test_run_deseq2_analysis`, `test_run_limma_analysis`) were
      **not** run — they require an R installation/DESeq2, per the task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
