### PR TITLE
Add unit tests for parsing.py string-name helpers (#171)

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -225,6 +225,26 @@ def test_parse_gff3_attributes(attrs, expected):
     assert res == expected
 
 
+@pytest.mark.parametrize('input_string,expected', [
+    ('P34544', 'P34544'),  # standard 6-character accession, letter outside the O/P/Q range
+    ('Q27395', 'Q27395'),  # standard 6-character accession with an O/P/Q prefix
+    ('O17395', 'O17395'),  # standard 6-character accession with an O/P/Q prefix
+    ('A0A0K3AVL7', 'A0A0K3AVL7'),  # extended 10-character accession format
+    ('sp|P34544|GENE_HUMAN', 'P34544'),  # accession embedded in a UniProt FASTA header
+    ('UniProtKB:Q27395', 'Q27395'),  # accession embedded after a database prefix
+    ('P34544-2', 'P34544'),  # isoform suffix is not part of the match and is dropped
+    ('P34544.1', 'P34544'),  # version suffix is not part of the match and is dropped
+    ('P34544-2.3', 'P34544'),  # combined isoform + version suffix is dropped
+    ('not a uniprot id', None),  # no match anywhere in the string
+    ('', None),  # empty string
+    ('p34544', None),  # malformed: lowercase is not a valid accession (case-sensitive)
+    ('P3454', None),  # malformed: one character too short to be a valid accession
+    ('unicode text café P34544 café', 'P34544'),  # valid id surrounded by unicode text
+])
+def test_parse_uniprot_id(input_string, expected):
+    assert parse_uniprot_id(input_string) == expected
+
+
 @pytest.mark.parametrize('allow_unicode,string,expected', [
     (False, 'text', 'text'),
     (False, 'text with spaces', 'text-with-spaces'),
@@ -237,6 +257,65 @@ def test_parse_gff3_attributes(attrs, expected):
 def test_slugify(allow_unicode, string, expected):
     res = slugify(string, allow_unicode)
     assert res == expected
+
+
+@pytest.mark.parametrize('s1,s2,expected', [
+    ('hello_world', 'goodbye_world', '_world'),  # shared suffix is the longest common substring
+    ('abcdef', 'xabcdefy', 'abcdef'),  # one string fully contained within the other
+    ('abc', 'xyz', ''),  # no common substring at all
+    ('same', 'same', 'same'),  # identical strings: LCS is the whole string
+    ('', '', ''),  # both strings empty
+    ('', 'abc', ''),  # one string empty
+    ('cafe123', 'cafe456', 'cafe'),  # shared prefix
+    ('café123', 'café456', 'café'),  # unicode shared prefix
+])
+def test_longest_common_substring(s1, s2, expected):
+    assert longest_common_substring(s1, s2) == expected
+
+
+@pytest.mark.parametrize('strings,expected', [
+    ([], ''),  # empty input
+    (['hello'], 'hello'),  # single item: the whole string is returned as-is
+    (['file_A.txt', 'file_B.txt'], '.txt'),  # a real shared suffix
+    (['abc', 'abc', 'abc'], 'abc'),  # all-identical inputs: the whole string is the suffix
+    (['apple', 'banana'], ''),  # no common suffix
+    (['', ''], ''),  # all strings empty
+    (['a', 'ba', 'cba'], 'a'),  # strings of different lengths, suffix bounded by the shortest one
+    (['日本語abc', '中国語abc'], '語abc'),  # unicode suffix
+])
+def test_common_suffix(strings, expected):
+    assert common_suffix(strings) == expected
+
+
+@pytest.mark.parametrize('s,suffix,expected', [
+    ('sample_trimmed', '_trimmed', 'sample'),  # single suffix given as a plain string
+    ('sample_trimmed', ['_sorted', '_trimmed'], 'sample'),  # suffix found within a list of candidates
+    ('sample', '_trimmed', 'sample'),  # no matching suffix: string is returned unchanged
+    ('sample_trimmed', ['med', '_trimmed'], 'sample'),  # longest matching suffix wins over a shorter one
+    ('sample_med', ['_trimmed', 'med'], 'sample_'),  # falls back to a shorter suffix when the longest doesn't match
+    ('sample', [], 'sample'),  # empty suffix list: string is returned unchanged
+    ('café_trimmed', '_trimmed', 'café'),  # unicode string
+    ('', '_trimmed', ''),  # empty string
+    ('_trimmed', '_trimmed', ''),  # the whole string is the suffix
+])
+def test_remove_suffix(s, suffix, expected):
+    assert remove_suffix(s, suffix) == expected
+
+
+@pytest.mark.parametrize('file_pairs,expected', [
+    ([], []),  # empty input
+    ([('sample1_R1', 'sample1_R2')], ['sample1_R']),  # single pair
+    ([('sample1_R1', 'sample1_R2'), ('sample2_R1', 'sample2_R2')], ['sample1', 'sample2']),  # two pairs
+    ([('ctrl1_R1', 'ctrl1_R2'), ('ctrl2_R1', 'ctrl2_R2'), ('treat1_R1', 'treat1_R2')],
+     ['ctrl', 'ctrl2_R', 'treat']),  # three pairs, uneven trimming across pairs
+    ([('abc', 'xyz')], ['abcxyz']),  # no common substring: names are concatenated
+    ([('same', 'same')], ['same']),  # all-identical inputs
+    ([('sample1_R1_trimmed', 'sample1_R2_trimmed')], ['sample1_R']),  # known suffixes are stripped first
+    ([('x_R1', 'x_R2'), ('x_R1', 'x_R2')], ['x_R1x_R2', 'x_R1x_R2']),  # duplicate pairs: trimming to empty is avoided
+    ([('café_R1', 'café_R2')], ['café_R']),  # unicode
+])
+def test_generate_common_name(file_pairs, expected):
+    assert generate_common_name(file_pairs) == expected
 
 
 @pytest.mark.parametrize('regex,repl,item,expected', [


### PR DESCRIPTION
Closes #171

## Summary

Adds unit tests in `tests/test_parsing.py` for five previously-untested pure functions in `rnalysis/utils/parsing.py`:

- **`test_parse_uniprot_id`** (14 cases): standard 6-char accessions (both O/P/Q-prefixed and not), the extended 10-char accession format, accessions embedded in a FASTA header / database-prefixed string, isoform suffixes (`P34544-2`), version suffixes (`P34544.1`), combined isoform+version suffixes, no-match text, empty string, case-sensitivity (lowercase does not match), a too-short malformed ID, and a unicode-surrounded ID. All assert the exact returned string or `None`.
- **`test_longest_common_substring`** (8 cases): shared suffix, one string fully contained in the other, no common substring (`''`), identical strings, both/one string empty, and a unicode shared prefix.
- **`test_common_suffix`** (8 cases): empty list (`''`), single-item list (returns the whole string — this is real, verified behavior, not a common suffix in the usual sense), a genuine shared suffix, all-identical strings, no common suffix, all-empty strings, strings of different lengths, and a unicode suffix.
- **`test_remove_suffix`** (9 cases): string vs. list suffix argument, no match (unchanged), longest-matching-suffix-wins when multiple suffixes in the list match, falling back to a shorter suffix when the longest doesn't match, empty suffix list, unicode, empty string, and the whole string being the suffix.
- **`test_generate_common_name`** (9 cases): empty input, single pair, two pairs, three pairs (exercises the cross-pair "overall LCS" comparison and its uneven per-pair trimming), no common substring (falls back to concatenation), all-identical pair, pre-stripping of the hardcoded `_trimmed`/`_sorted`/`_` suffixes, duplicate pairs (exercises the guard that avoids trimming a result down to an empty string), and unicode.

All expected values were derived by hand-tracing the algorithms (not by re-running the implementation and copying its output), then cross-checked by execution. As an extra check, I temporarily flipped three branches in `parsing.py` locally (match/no-match in `parse_uniprot_id`, sort order in `remove_suffix`, and a redundant guard in `common_suffix`) and confirmed the relevant tests failed for the right reason, then reverted — `git diff` on `rnalysis/utils/parsing.py` is empty, no production code was changed.

## Notes / things found while testing (not fixed, per task scope)

- `generate_common_name`'s "prepare output" loop (`for s1, s2, lcs in lcs_list:`) leaks `s1`/`s2` into the enclosing scope, and a later list comprehension (`lcs_only = [... if len(result) <= len(s1 + s2)]`) reads those leaked values from the *last* iteration of that loop rather than per-pair. This is existing behavior (not changed here) but is subtle — flagging it in case it's worth a follow-up issue.
- `common_suffix`'s `if len(strings) == 1: return strings[0]` branch is actually unreachable-equivalent: for a true single-item list, falling through to the `min`/`max` general path produces the same result (since `min([x]) == max([x]) == x`), because the earlier `if not strings` guard already handles the empty case. Confirmed via a mutation test. Not a bug, just redundant code — no change made.

## Test plan

- [x] `conda run --no-capture-output -n rnalysis python -m pytest tests/test_parsing.py -q` — 180 passed (up from 132 before this change; no failures, no regressions to existing tests).
- [x] Verified test sensitivity via temporary branch-flip mutations (reverted, no production diff).
- [ ] Did NOT run the full suite / R / kallisto / bowtie2 / network / GUI paths — out of scope per task instructions (this is a pure-function, no-network, no-Qt test addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
