### PR TITLE
Add fast unit tests for kallisto transcript-to-gene summation (#172)

### DIFF
--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -2,8 +2,10 @@ import gzip
 import platform
 from unittest.mock import Mock
 
+import polars as pl
 import pytest
 import yaml
+from polars.testing import assert_frame_equal
 
 from rnalysis import __version__, fastq
 from rnalysis.fastq import *
@@ -475,6 +477,115 @@ def test_kallisto_quantify_paired_end_command(monkeypatch, r1_files, r2_files, o
                                  seek_fusion_genes=seek_fusion_genes)
     assert sorted(pairs_covered) == sorted(pairs_to_cover)
     assert output_processed == [True]
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# transcript->gene summation (issue #172): fast unit tests on synthetic inputs, no kallisto binary involved.
+# ---------------------------------------------------------------------------------------------------------------
+
+def _abundance_tsv_text(rows):
+    header = '\t'.join(['target_id', 'length', 'eff_length', 'est_counts', 'tpm'])
+    lines = [header]
+    for target_id, length, eff_length, est_counts, tpm in rows:
+        lines.append('\t'.join([target_id, str(length), str(eff_length), str(est_counts), str(tpm)]))
+    return '\n'.join(lines) + '\n'
+
+
+def test_merge_kallisto_outputs(tmp_path):
+    (tmp_path / 'sample_A').mkdir()
+    (tmp_path / 'sample_B').mkdir()
+    (tmp_path / 'sample_A' / 'abundance.tsv').write_text(_abundance_tsv_text([
+        ('ENST1', 100, 80, 10, 1000.0),
+        ('ENST2', 200, 180, 30, 3000.0),
+        ('ENST3', 150, 130, 100, 6000.0),
+    ]))
+    (tmp_path / 'sample_B' / 'abundance.tsv').write_text(_abundance_tsv_text([
+        ('ENST1', 100, 80, 5, 500.0),
+        ('ENST2', 200, 180, 15, 1500.0),
+        ('ENST3', 150, 130, 50, 3000.0),
+    ]))
+
+    counts, tpm = fastq._merge_kallisto_outputs(tmp_path, ['sample_A', 'sample_B'])
+
+    truth_counts = pl.DataFrame(
+        {'': ['ENST1', 'ENST2', 'ENST3'], 'sample_A': [10, 30, 100], 'sample_B': [5, 15, 50]})
+    truth_tpm = pl.DataFrame(
+        {'': ['ENST1', 'ENST2', 'ENST3'], 'sample_A': [1000.0, 3000.0, 6000.0],
+         'sample_B': [500.0, 1500.0, 3000.0]})
+
+    assert_frame_equal(counts, truth_counts)
+    assert_frame_equal(tpm, truth_tpm)
+
+
+def test_merge_kallisto_outputs_missing_sample_raises(tmp_path):
+    (tmp_path / 'sample_A').mkdir()
+    (tmp_path / 'sample_A' / 'abundance.tsv').write_text(_abundance_tsv_text([
+        ('ENST1', 100, 80, 10, 1000.0),
+    ]))
+
+    with pytest.raises(FileNotFoundError, match='sample_B'):
+        fastq._merge_kallisto_outputs(tmp_path, ['sample_A', 'sample_B'])
+
+
+# tiny, hand-verifiable GTF fixture (shared with tests/test_genome_annotation.py's map_transcripts_to_genes
+# characterization tests): gene ENSG00000000001.3 (GENEA) has two transcripts, gene ENSG00000000002.1 (GENEB)
+# has one. Both genes/transcripts carry version attributes, so the default (use_version=True, split_ids=True)
+# lookup that _sum_transcripts_to_genes tries first resolves versioned transcript/gene IDs.
+_KALLISTO_SUMMATION_GTF = 'tests/test_files/test_gtf_ensembl.gtf'
+
+
+def _kallisto_summation_inputs():
+    tpm = pl.DataFrame({
+        '': ['ENST00000000001.2', 'ENST00000000002.1', 'ENST00000000003.4'],
+        'sample_A': [1000.0, 3000.0, 6000.0],
+        'sample_B': [500.0, 1500.0, 3000.0],
+    })
+    counts = pl.DataFrame({
+        '': ['ENST00000000001.2', 'ENST00000000002.1', 'ENST00000000003.4'],
+        'sample_A': [10, 30, 100],
+        'sample_B': [5, 15, 50],
+    })
+    return tpm, counts
+
+
+def test_sum_transcripts_to_genes_scaled_tpm():
+    tpm, counts = _kallisto_summation_inputs()
+
+    result = fastq._sum_transcripts_to_genes(tpm, counts, _KALLISTO_SUMMATION_GTF, 'scaled_tpm')
+
+    # library size (counts-per-million divisor) = sum(counts)/1e6: sample_A=140/1e6, sample_B=70/1e6.
+    # scaled_tpm gene count = sum(tpm across the gene's transcripts) * library_size.
+    # GENEA (ENST1+ENST2): sample_A=(1000+3000)*140e-6=0.56, sample_B=(500+1500)*70e-6=0.14
+    # GENEB (ENST3 only):  sample_A=6000*140e-6=0.84,        sample_B=3000*70e-6=0.21
+    truth = pl.DataFrame({
+        'Gene ID': ['ENSG00000000001.3', 'ENSG00000000002.1'],
+        'sample_A': [0.56, 0.84],
+        'sample_B': [0.14, 0.21],
+    })
+    assert_frame_equal(result, truth)
+
+
+def test_sum_transcripts_to_genes_raw():
+    tpm, counts = _kallisto_summation_inputs()
+
+    result = fastq._sum_transcripts_to_genes(tpm, counts, _KALLISTO_SUMMATION_GTF, 'raw')
+
+    # plain per-gene sum of the transcript-level counts.
+    # GENEA (ENST1+ENST2): sample_A=10+30=40, sample_B=5+15=20
+    # GENEB (ENST3 only):  sample_A=100,      sample_B=50
+    truth = pl.DataFrame({
+        'Gene ID': ['ENSG00000000001.3', 'ENSG00000000002.1'],
+        'sample_A': [40, 100],
+        'sample_B': [20, 50],
+    })
+    assert_frame_equal(result, truth)
+
+
+def test_sum_transcripts_to_genes_invalid_method_raises():
+    tpm, counts = _kallisto_summation_inputs()
+
+    with pytest.raises(ValueError, match="Invalid value for 'summation_method'"):
+        fastq._sum_transcripts_to_genes(tpm, counts, _KALLISTO_SUMMATION_GTF, 'not_a_real_method')
 
 
 def test_trim_adapters_single_end():


### PR DESCRIPTION
Closes #172

## Summary

The kallisto transcript-to-gene summation arithmetic (`rnalysis/fastq.py::_sum_transcripts_to_genes` and `_merge_kallisto_outputs`) was previously only exercised indirectly by binary-dependent integration tests (`test_kallisto_quantify_single_end`/`_paired_end`), which require the kallisto executable and never run in most environments. This PR adds fast, synthetic-input unit tests in `tests/test_fastq.py` that exercise the pure summation logic directly, with no kallisto binary, R, network, or Qt involved.

New tests (all in `tests/test_fastq.py`):

- `test_merge_kallisto_outputs` — builds two small fake per-sample `abundance.tsv` files (tab-separated `target_id/length/eff_length/est_counts/tpm`) in a `tmp_path`, calls `_merge_kallisto_outputs`, and asserts the merged `counts`/`tpm` Polars DataFrames match exact expected values (not just shape).
- `test_merge_kallisto_outputs_missing_sample_raises` — omits one sample's output directory and asserts `FileNotFoundError` is raised, mentioning the missing sample name.
- `test_sum_transcripts_to_genes_scaled_tpm` — builds tiny synthetic `tpm`/`counts` DataFrames (2 transcripts on one gene, 1 transcript on another) against the existing minimal fixture `tests/test_files/test_gtf_ensembl.gtf`, and asserts the exact `scaled_tpm`-summed gene-level values, verifying the `* library_size` (counts-per-million) rescaling numerically (e.g. gene A = `(1000+3000) tpm * 140e-6 library_size = 0.56`).
- `test_sum_transcripts_to_genes_raw` — same fixture/inputs, `summation_method='raw'`, asserts the plain per-gene sum of transcript-level counts (e.g. gene A = `10+30 = 40`).
- `test_sum_transcripts_to_genes_invalid_method_raises` — asserts `ValueError` for an unrecognized `summation_method`.

`tests/test_files/test_gtf_ensembl.gtf` (already used by `tests/test_genome_annotation.py`'s `map_transcripts_to_genes` characterization tests) is reused as the tiny GTF fixture, so `_sum_transcripts_to_genes`'s call into `genome_annotation.map_transcripts_to_genes` is exercised with real GTF parsing rather than mocked out. `map_transcripts_to_genes` itself already has thorough direct coverage in `tests/test_genome_annotation.py` (Ensembl/GENCODE/WormBase fixtures, malformed-GTF, real kallisto GTF), so no additional tests were added there.

All expected values were independently verified against the real implementation via ad-hoc scripts before being written into the tests. As a red/green sanity check, a truth value in `test_sum_transcripts_to_genes_raw` was temporarily set to a wrong number, confirmed the test failed for the right reason (`AssertionError: DataFrames are different`), then reverted to the correct value.

## Test plan

- [x] `conda run --no-capture-output -n rnalysis python -m pytest tests/test_fastq.py -q -k "merge_kallisto_outputs or sum_transcripts_to_genes"` — 5 passed, no kallisto/R/network/Qt required.
- [x] Full `tests/test_fastq.py` run locally: 61 passed, 1 xfailed, 9 failed — all 9 failures are pre-existing and unrelated to this change (kallisto/bowtie2/Rsubread binaries are not installed in this environment: `FileNotFoundError`/subprocess-assertion failures in tests this PR does not touch). Confirmed via `git diff --stat` that only `tests/test_fastq.py` was modified.
- Not run: anything requiring the actual kallisto/bowtie2/R/Rsubread binaries, network access, or a Qt display (out of scope per the issue — the point is to cover the pure summation logic without the binary).

No production code was changed; this is a test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
