### PR TITLE
Fix IndexError in common_suffix on uneven-length inputs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,7 @@ Fixed
 * Fixed a bug where automatically detecting the organism or gene-ID type from a set of gene IDs (via Ensembl) failed with an ``HTTP 400`` error, because the request body sent to Ensembl was double-encoded. The request is now formatted correctly.
 * Fixed a bug where a malformed or unreachable external service (PantherDB, UniProt, Ensembl, or PhylomeDB) could crash RNAlysis on startup while it loaded the lists of supported organisms and gene-ID types. These lookups now degrade gracefully to an empty list with a warning, and their network requests use timeouts so a stalled service can't freeze startup.
 * Fixed a crash in ``CountFilter.average_replicate_samples`` when ``function='median'``: it relied on ``DataFrame.median_horizontal``, which was removed in Polars 1.x. The row-wise median is now computed correctly.
+* Fixed a crash (``IndexError``) in automatic common-name generation for inputs of uneven length.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -459,14 +459,13 @@ def common_suffix(strings):
     """Find the common suffix among a list of strings."""
     if not strings:
         return ''
-    if len(strings) == 1:
-        return strings[0]
     s1 = min(strings)
     s2 = max(strings)
-    for i, c in enumerate(reversed(s1)):
-        if c != s2[-(i + 1)]:
+    max_overlap = min(len(s1), len(s2))
+    for i in range(max_overlap):
+        if s1[-(i + 1)] != s2[-(i + 1)]:
             return s1[len(s1) - i:]
-    return s1
+    return s1[len(s1) - max_overlap:]
 
 
 def remove_suffix(s: str, suffix: Union[str, List[str]]):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -282,6 +282,8 @@ def test_longest_common_substring(s1, s2, expected):
     (['', ''], ''),  # all strings empty
     (['a', 'ba', 'cba'], 'a'),  # strings of different lengths, suffix bounded by the shortest one
     (['日本語abc', '中国語abc'], '語abc'),  # unicode suffix
+    (['ab', 'aab'], 'ab'),  # lexicographically-smaller string is longer than the larger one (issue #180)
+    (['aac', 'ab'], ''),  # same as above, but with no shared suffix at all
 ])
 def test_common_suffix(strings, expected):
     assert common_suffix(strings) == expected


### PR DESCRIPTION
Closes #180

## Root cause

`common_suffix()` in `rnalysis/utils/parsing.py` picked `s1 = min(strings)` and
`s2 = max(strings)` **lexicographically** (not by length), then iterated
`reversed(s1)` and indexed `s2[-(i + 1)]` for every character of `s1`.

When the lexicographically-smaller string (`s1`) was *longer* than the
lexicographically-larger string (`s2`), and they shared a long-enough suffix,
the loop kept walking past the end of `s2` once `i + 1 > len(s2)`, raising
`IndexError: string index out of range`. This is reachable in production via
`generate_common_name -> common_suffix` in the FASTQ smart paired-end
sample-naming path (e.g. `common_suffix(['ab', 'aab'])`).

## Fix

Bound the comparison loop to `min(len(s1), len(s2))` so indexing into either
string can never go out of range:

```python
def common_suffix(strings):
    """Find the common suffix among a list of strings."""
    if not strings:
        return ''
    s1 = min(strings)
    s2 = max(strings)
    max_overlap = min(len(s1), len(s2))
    for i in range(max_overlap):
        if s1[-(i + 1)] != s2[-(i + 1)]:
            return s1[len(s1) - i:]
    return s1[len(s1) - max_overlap:]
```

Also removed the now-redundant `len(strings) == 1` early-return branch — the
general min/max path already returns the whole string for a single-element
list (verified by test and manual check).

Only `common_suffix` (and its tests) were touched; `generate_common_name` and
other functions are left untouched for a separate PR.

## Testing (TDD)

1. **Red** — added `(['ab', 'aab'], 'ab')` and `(['aac', 'ab'], '')` cases to
   `test_common_suffix` in `tests/test_parsing.py` and confirmed the first one
   reproduced the exact `IndexError: string index out of range` from the issue
   against the pre-fix code.
2. **Green** — applied the fix; all 10 `test_common_suffix` cases and the full
   `tests/test_parsing.py` module (182 tests) pass.
3. **Behavior preservation** — for every input that didn't crash before, the
   loop bound was already `len(s1)` in practice (since it only overflows when
   `len(s1) > len(s2)`), so bounding it to `min(len(s1), len(s2))` is a no-op
   for those cases; the existing pre-fix test cases (`[]`, single-element,
   real shared suffix, all-identical, no common suffix, all-empty,
   different-length strings, unicode) all still pass unchanged. Manually
   re-verified several of these plus new edge cases
   (`['', 'abc']`, `['sample_R1_trimmed.fastq', 'sample_R2_trimmed.fastq']`)
   against the fixed implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
