### PR TITLE
Fix variable scope leak in generate_common_name (#181)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,7 @@ Fixed
 * Fixed a bug where automatically detecting the organism or gene-ID type from a set of gene IDs (via Ensembl) failed with an ``HTTP 400`` error, because the request body sent to Ensembl was double-encoded. The request is now formatted correctly.
 * Fixed a bug where a malformed or unreachable external service (PantherDB, UniProt, Ensembl, or PhylomeDB) could crash RNAlysis on startup while it loaded the lists of supported organisms and gene-ID types. These lookups now degrade gracefully to an empty list with a warning, and their network requests use timeouts so a stalled service can't freeze startup.
 * Fixed a crash in ``CountFilter.average_replicate_samples`` when ``function='median'``: it relied on ``DataFrame.median_horizontal``, which was removed in Polars 1.x. The row-wise median is now computed correctly.
+* Fixed a bug where automatic common-name generation (used by the "smart" paired-end sample-naming option in the FASTQ functions) could produce an incorrect name when input file pairs differed in length, because a filtering step reused a loop variable left over from the last pair instead of each pair's own values.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -490,13 +490,16 @@ def generate_common_name(file_pairs):
 
     # Prepare output based on comparison
     initial_results = []
+    pair_lengths = []
     for s1, s2, lcs in lcs_list:
+        pair_lengths.append(len(s1) + len(s2))
         if len(lcs) > len(overall_lcs):
             initial_results.append(lcs)
         else:
             initial_results.append(s1 + s2)
-    # Find and trim common suffix from LCSs
-    lcs_only = [result for result in initial_results if len(result) <= len(s1 + s2)]
+    # Find and trim common suffix from LCSs (compare each result against its OWN pair's combined
+    # length, not the loop variables left over from the last iteration of the loop above)
+    lcs_only = [result for result, pair_length in zip(initial_results, pair_lengths) if len(result) <= pair_length]
     suffix = common_suffix(lcs_only)
     if suffix and len(lcs_only) > 1:
         trimmed_results = [

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -313,6 +313,12 @@ def test_remove_suffix(s, suffix, expected):
     ([('sample1_R1_trimmed', 'sample1_R2_trimmed')], ['sample1_R']),  # known suffixes are stripped first
     ([('x_R1', 'x_R2'), ('x_R1', 'x_R2')], ['x_R1x_R2', 'x_R1x_R2']),  # duplicate pairs: trimming to empty is avoided
     ([('café_R1', 'café_R2')], ['café_R']),  # unicode
+    # regression test for issue #181: a scope leak used the LAST pair's s1/s2 (from the loop
+    # variable) to filter every pair's result instead of each pair's own s1/s2. Since the last
+    # pair here is much shorter, the earlier (longer) pair's valid LCS result was wrongly
+    # excluded from the common-suffix computation, so the shared trailing "_R" was never trimmed.
+    ([('sampleA_long_name_R1', 'sampleA_long_name_R2'), ('sB_R1', 'sB_R2')],
+     ['sampleA_long_name', 'sB']),
 ])
 def test_generate_common_name(file_pairs, expected):
     assert generate_common_name(file_pairs) == expected


### PR DESCRIPTION
Closes #181

## The bug

In `generate_common_name` (`rnalysis/utils/parsing.py`), the loop:

```python
for s1, s2, lcs in lcs_list:
    ...
```

is followed by a comprehension that references `s1`/`s2`:

```python
lcs_only = [result for result in initial_results if len(result) <= len(s1 + s2)]
```

`s1`/`s2` are free variables resolved from the enclosing function scope, so after the loop
finishes they are bound to the **last** pair's values, not each element's own pair. Every
`result` in `initial_results` therefore got filtered against the *last* pair's combined name
length instead of its own.

When file-pair name lengths vary and the last pair happens to be short, this wrongly excludes
an earlier (longer) pair's valid LCS result from `lcs_only`. Since `lcs_only` feeds the
common-suffix computation used to trim a shared trailing fragment (like the `_R` left over from
`R1`/`R2`), losing an entry from it can suppress that trim entirely — producing an incorrect
common name. This is reachable via the FASTQ "smart" paired-end sample-naming path
(`fastq.py`, `new_sample_names == 'smart'`).

## The fix

Capture each pair's own combined length (`len(s1) + len(s2)`) alongside its result while still
inside the loop, and filter using that per-item value instead of the leaked loop variable:

```python
initial_results = []
pair_lengths = []
for s1, s2, lcs in lcs_list:
    pair_lengths.append(len(s1) + len(s2))
    if len(lcs) > len(overall_lcs):
        initial_results.append(lcs)
    else:
        initial_results.append(s1 + s2)
# Find and trim common suffix from LCSs (compare each result against its OWN pair's combined
# length, not the loop variables left over from the last iteration of the loop above)
lcs_only = [result for result, pair_length in zip(initial_results, pair_lengths) if len(result) <= pair_length]
```

Only `generate_common_name` was touched — `common_suffix` and other functions are left as-is
(a separate PR covers those, per PR #176's review notes).

## TDD

Added a regression case to the existing `test_generate_common_name` parametrization in
`tests/test_parsing.py`, using two pairs of very different length so the last-pair leak bites:

```python
([('sampleA_long_name_R1', 'sampleA_long_name_R2'), ('sB_R1', 'sB_R2')],
 ['sampleA_long_name', 'sB']),
```

- **Before the fix**: `generate_common_name` returned `['sampleA_long_name_R', 'sB_R']` — the
  longer pair's valid LCS result was excluded from `lcs_only` (filtered against the short last
  pair's length), `lcs_only` ended up with only 1 element, so the `len(lcs_only) > 1` guard
  skipped trimming altogether and the shared `_R` suffix was never removed. Confirmed this test
  fails on current code for that reason (all 9 pre-existing parametrized cases still passed).
- **After the fix**: `generate_common_name` returns `['sampleA_long_name', 'sB']`, correctly
  trimming the shared `_R`.

All 181 tests in `tests/test_parsing.py` pass, including the 9 pre-existing
`test_generate_common_name` cases, unchanged — confirming they never pinned the buggy behavior
(per PR #176's review) and don't need to change for this fix.

```
conda run --no-capture-output -n rnalysis python -m pytest tests/test_parsing.py -q
181 passed, 1 warning in 2.20s
```

## Changelog

Since this can change auto-generated common/sample names for the (buggy) divergent-pair-length
edge case, added a `HISTORY.rst` entry under the unreleased `4.2.1` section's `Fixed` list.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
