### PR TITLE
Harden PantherDB ortholog/paralog mapping against empty responses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,7 @@ Fixed
 * Fixed a crash in ``CountFilter.average_replicate_samples`` when ``function='median'``: it relied on ``DataFrame.median_horizontal``, which was removed in Polars 1.x. The row-wise median is now computed correctly.
 * Fixed a bug where automatic common-name generation (used by the "smart" paired-end sample-naming option in the FASTQ functions) could produce an incorrect name when input file pairs differed in length, because a filtering step reused a loop variable left over from the last pair instead of each pair's own values.
 * Fixed a crash (``IndexError``) in automatic common-name generation for inputs of uneven length.
+* Fixed a bug where mapping orthologs or paralogs through the PantherDB service could crash the whole analysis when PantherDB intermittently returned an empty response for a gene (an empty ``HTTP 200`` body, which its retry mechanism does not cover). Such requests are now retried, and if the response stays empty that single gene is skipped with a warning instead of aborting the entire mapping.
 
 
 4.2.0 (2026-05-30)

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -1793,11 +1793,42 @@ class PantherOrthologMapper:
     API_URL = 'https://www.pantherdb.org'
     RETRIES = RandomExpRetry(total=5, backoff_factor=0.25, status_forcelist=[500, 502, 503, 504])
     HEADERS = {'accept': 'application/json'}
+    # PantherDB intermittently answers a mapping request with an empty HTTP 200 body (its urllib3
+    # Retry only fires on 5xx/connection errors, not on a 200), which makes req.json() raise
+    # JSONDecodeError. Retry the request a few times before giving up on a gene.
+    EMPTY_RESPONSE_RETRIES = 3
+    EMPTY_RESPONSE_BACKOFF = 0.25
 
     def __init__(self, map_to_organism, map_from_organism='auto', gene_id_type='auto'):
         self.gene_id_type = gene_id_type
         self.map_from_organism = map_from_organism
         self.map_to_organism = map_to_organism
+
+    def _fetch_mapped(self, session: requests.Session, url: str, req_data: dict, headers: dict = None):
+        """POST to a PantherDB mapping endpoint and return its ``search.mapping.mapped`` payload.
+
+        Returns an empty list when the service answers with an empty/invalid body that stays empty
+        after ``EMPTY_RESPONSE_RETRIES`` attempts, so a single degraded response skips that one gene
+        instead of raising ``JSONDecodeError`` and aborting the whole ortholog/paralog mapping. A
+        valid JSON response that simply has no mapping for the gene also yields an empty list.
+        """
+        for attempt in range(self.EMPTY_RESPONSE_RETRIES):
+            req = session.post(url, headers=headers, params=req_data)
+            req.raise_for_status()
+            try:
+                payload = req.json()
+            except requests.exceptions.JSONDecodeError:
+                if attempt + 1 < self.EMPTY_RESPONSE_RETRIES:
+                    time.sleep(self.EMPTY_RESPONSE_BACKOFF * (attempt + 1))
+                    continue
+                warnings.warn(f"PantherDB returned an empty response for '{req_data.get('geneInputList')}' after "
+                              f"{self.EMPTY_RESPONSE_RETRIES} attempts; skipping this gene.")
+                break  # retries exhausted on an empty body -> fall through to the empty result below
+            try:
+                return payload['search']['mapping']['mapped']
+            except KeyError:
+                return []
+        return []
 
     def translate_ids(self, ids: Tuple[str, ...], session=None) -> Tuple[List[str], List[str]]:
         if self.gene_id_type == 'auto':
@@ -1822,10 +1853,8 @@ class PantherOrthologMapper:
             req_data = dict(geneInputList=from_id, organism=str(self.map_from_organism),
                             targetOrganism=str(self.map_to_organism),
                             orthologType='all' if filter_least_diverged else 'LDO')
-            req = session.post(url, headers=self.HEADERS, params=req_data)
-            req.raise_for_status()
+            req_output = self._fetch_mapped(session, url, req_data, headers=self.HEADERS)
             try:
-                req_output = req.json()['search']['mapping']['mapped']
                 for mapping in parsing.data_to_list(req_output):
                     if len(mapping) <= 1:
                         continue
@@ -1872,11 +1901,8 @@ class PantherOrthologMapper:
         n_mapped = 0
         for from_id in tqdm(translated_ids, 'Mapping paralogs', unit='genes'):
             req_data = dict(geneInputList=from_id, organism=str(self.map_from_organism), homologType='P')
-            req = session.post(url, params=req_data)
-            req.raise_for_status()
-
+            req_output = self._fetch_mapped(session, url, req_data)
             try:
-                req_output = req.json()['search']['mapping']['mapped']
                 for mapping in parsing.data_to_list(req_output):
                     if len(mapping) <= 1:
                         continue
@@ -1896,7 +1922,7 @@ class PantherOrthologMapper:
         _, mapping_one2many = translate_mappings(ids, translated_ids, {}, mapping_one2many)
 
         if n_mapped < len(translated_ids):
-            warnings.warn(f"Paralob mapping found for only {n_mapped} out of {len(translated_ids)} gene IDs.")
+            warnings.warn(f"Paralog mapping found for only {n_mapped} out of {len(translated_ids)} gene IDs.")
 
         return OrthologDict(mapping_one2many)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1815,6 +1815,99 @@ class TestPantherOrthologMapper:
             assert all(id_pattern.match(v) for v in values), f"unexpected paralog ID format(s): {values}"
 
 
+class _PantherIdentityTranslator:
+    """Stand-in for GeneIDTranslator so PantherOrthologMapper.translate_ids() needs no network."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run(self, ids):
+        return GeneIDDict({this_id: this_id for this_id in ids})
+
+
+def _panther_fake_session(json_side_effect):
+    """A session whose every .post() returns a 200 response with the given .json() side effect."""
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.side_effect = json_side_effect
+    session = MagicMock()
+    session.post.return_value = resp
+    return session
+
+
+def _empty_body_error():
+    # what requests raises when the body of a 200 response is empty / not valid JSON
+    raise requests.exceptions.JSONDecodeError('Expecting value', '', 0)
+
+
+@pytest.mark.unit
+def test_panther_get_orthologs_degrades_gracefully_on_empty_response(monkeypatch):
+    # PantherDB intermittently answers with an empty HTTP 200 body (its urllib3 Retry only covers
+    # 5xx/connection errors, not a 200), so req.json() raises JSONDecodeError. The mapper must not
+    # crash the whole run -- it should retry and, if the body stays empty, degrade to an empty
+    # result (the same graceful skip it already does for a JSON response missing the mapping keys).
+    monkeypatch.setattr(io, 'GeneIDTranslator', _PantherIdentityTranslator)
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)
+    fake_session = _panther_fake_session(_empty_body_error)
+    monkeypatch.setattr(io, 'get_session', lambda retries: fake_session)
+
+    mapper = PantherOrthologMapper(map_to_organism=9606, map_from_organism=6239,
+                                   gene_id_type='UniProtKB AC/ID')
+    one2one, one2many = mapper.get_orthologs(('G5EDF7', 'P34544'), 'first', True)
+
+    assert isinstance(one2one, OrthologDict) and isinstance(one2many, OrthologDict)
+    assert one2one.mapping_dict == {}
+    assert one2many.mapping_dict == {}
+    # each of the 2 genes was retried the configured number of times before giving up
+    assert fake_session.post.call_count == 2 * mapper.EMPTY_RESPONSE_RETRIES
+
+
+@pytest.mark.unit
+def test_panther_get_orthologs_retries_empty_response_then_succeeds(monkeypatch):
+    # a transient empty 200 on the first attempt should be retried, and the recovered response
+    # used -- so a momentary PantherDB hiccup doesn't silently drop a gene's orthologs.
+    monkeypatch.setattr(io, 'GeneIDTranslator', _PantherIdentityTranslator)
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)
+
+    good_payload = {'search': {'mapping': {'mapped': [
+        {'id': 'x', 'target_gene': 'HUMAN|UniProtKB=P12345', 'ortholog': 'LDO'}]}}}
+    calls = {'n': 0}
+
+    def empty_then_good():
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise requests.exceptions.JSONDecodeError('Expecting value', '', 0)
+        return good_payload
+
+    fake_session = _panther_fake_session(empty_then_good)
+    monkeypatch.setattr(io, 'get_session', lambda retries: fake_session)
+
+    mapper = PantherOrthologMapper(map_to_organism=9606, map_from_organism=6239,
+                                   gene_id_type='UniProtKB AC/ID')
+    one2one, one2many = mapper.get_orthologs(('P34544',), 'first', True)
+
+    assert one2one.mapping_dict == {'P34544': 'P12345'}
+    assert one2many.mapping_dict == {'P34544': ['P12345']}
+    assert calls['n'] == 2  # failed once, retried once, then succeeded
+
+
+@pytest.mark.unit
+def test_panther_get_paralogs_degrades_gracefully_on_empty_response(monkeypatch):
+    # same resilience requirement as get_orthologs, for the paralog endpoint
+    monkeypatch.setattr(io, 'GeneIDTranslator', _PantherIdentityTranslator)
+    monkeypatch.setattr(io.time, 'sleep', lambda *args, **kwargs: None)
+    fake_session = _panther_fake_session(_empty_body_error)
+    monkeypatch.setattr(io, 'get_session', lambda retries: fake_session)
+
+    mapper = PantherOrthologMapper(map_to_organism=6239, map_from_organism=6239,
+                                   gene_id_type='UniProtKB AC/ID')
+    paralogs = mapper.get_paralogs(('G5EDF7', 'P34707'))
+
+    assert isinstance(paralogs, OrthologDict)
+    assert paralogs.mapping_dict == {}
+    assert fake_session.post.call_count == 2 * mapper.EMPTY_RESPONSE_RETRIES
+
+
 class TestEnsemblOrthologMapper:
 
     # Define a fixture to create an instance of EnsemblOrthologMapper for testing


### PR DESCRIPTION
## Summary

Hardens `PantherOrthologMapper` against a real robustness gap that surfaced as a **CI failure in the network tier** (`tests/test_io.py::TestPantherOrthologMapper::test_get_orthologs` / `test_get_paralogs`).

That tier runs on exactly one matrix cell (`ubuntu-latest / 3.13`), so it has no redundancy — a single PantherDB hiccup turns the whole PR check red. During the failing run, PantherDB intermittently answered a mapping request with an **empty HTTP 200 body**. Its urllib3 `Retry` only fires on 5xx/connection errors (not a 200), so `req.json()['search']['mapping']['mapped']` raised an uncaught `requests.exceptions.JSONDecodeError` (which is **not** a `KeyError`, so the existing `except KeyError` didn't catch it) and aborted the entire ortholog/paralog mapping.

This violates the project's "never let one dead service crash the app / degrade gracefully" rule.

## What changed

- New `PantherOrthologMapper._fetch_mapped()` helper shared by `get_orthologs` and `get_paralogs`:
  - **Retries** an empty/invalid `200` a few times (`EMPTY_RESPONSE_RETRIES = 3`, small backoff) — so a *transient* empty body recovers the real data and no gene is silently dropped.
  - If it stays empty, **skips that one gene with a warning** and returns an empty payload, instead of crashing the whole run.
  - A valid JSON response that simply has no mapping for the gene still degrades to an empty result, exactly as before.
- `raise_for_status()` (HTTP-error) behaviour and the per-entry `except KeyError` skip are **unchanged** — only the JSON-decode path gains retry + graceful degrade.

## Tests (TDD, red → green)

Three mocked unit tests in `tests/test_io.py`, explicitly marked `@pytest.mark.unit` so they run on **all 9 CI cells** (fully mocked — no network):

- `test_panther_get_orthologs_degrades_gracefully_on_empty_response` — every `200` body is empty → returns empty dicts (no crash), and each gene is retried `EMPTY_RESPONSE_RETRIES` times.
- `test_panther_get_orthologs_retries_empty_response_then_succeeds` — first attempt empty, retry returns valid data → the recovered mapping is used (proves the happy-path parse is intact).
- `test_panther_get_paralogs_degrades_gracefully_on_empty_response` — same for the paralog endpoint.

All three fail on `development` (uncaught `JSONDecodeError`) and pass with the fix.

## Validation

- New tests: **3 passed** locally; confirmed they classify as `unit` (run everywhere) and **not** `integration_net`.
- Broader mocked ortholog/translate set in `test_io.py`: **54 passed, 6 skipped** (the live PantherDB class is skipped without network), no regressions.
- Could not exercise the live PantherDB endpoint locally (no network / `PANTHERDB_AVAILABLE` is False here); the happy-path logic is unchanged and is covered by the retry-recovery test.
- `HISTORY.rst` entry added (behaviour only changes in the failure case: crash → retry/skip-with-warning).

Independent of #178 (that test-only PR was fine; this fixes the actual network-tier red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
