### PR TITLE
Docs: fix broken image/figure references in user guides

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -768,9 +768,9 @@ Finally, you can use a model selection method to estimate the number of clusters
 
 To help in evaluating the result of these model selection methods, *RNAlysis* will also plot a summary of their outcome:
 
-.. image:: /figures/ gap_statistic.png
+.. image:: /figures/gap_statistic.png
            :width: 60 %
-.. image:: /figures/ silhouette.png
+.. image:: /figures/silhouette.png
            :width: 30 %
 
 |
@@ -1368,7 +1368,7 @@ Gene Ontology terms have a somewhat hierarchical relationship that is defined as
 
 For example:
 
-        .. figure:: /figures/http://geneontology.org/assets/hexose-biosynthetic-process.png
+        .. figure:: http://geneontology.org/assets/hexose-biosynthetic-process.png
            :align:   center
            :scale: 35 %
 

--- a/docs/source/user_guide_gui.rst
+++ b/docs/source/user_guide_gui.rst
@@ -486,9 +486,9 @@ Finally, you can use a selection algorithm to estimate a good number of clusters
 
 To help in evaluating the result of these selection algorithms, *RNAlysis* will also plot a summary of their outcome:
 
-.. image:: /figures/ gap_statistic.png
+.. image:: /figures/gap_statistic.png
            :width: 60 %
-.. image:: /figures/ silhouette.png
+.. image:: /figures/silhouette.png
            :width: 30 %
 
 |
@@ -1068,7 +1068,7 @@ Gene Ontology terms have a somewhat hierarchical relationship that is defined as
 
 For example:
 
-        .. figure:: /figures/http://geneontology.org/assets/hexose-biosynthetic-process.png
+        .. figure:: http://geneontology.org/assets/hexose-biosynthetic-process.png
            :align:   center
            :scale: 35 %
 


### PR DESCRIPTION
Fixes #109

- Removed stray space in 4 image refs (`/figures/ gap_statistic.png` etc.)
- Fixed 2 hexose figures where a local path was glued onto the external URL