### PR TITLE
feat(annotation): filter/annotate a table by any GTF/GFF attribute (#154)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 4.3.0 (unreleased)
 -------------------
 
+Added
+******
+* You can now filter a table by **any** attribute in a GTF/GFF annotation file, not just biotype (``Filter.filter_by_gtf_attribute``) — for example, keep only the genes on a particular chromosome or strand, from a particular annotation source, or of a particular biotype. The reserved attribute names ``chromosome``, ``source`` and ``strand`` read the corresponding columns of the annotation file, while any other name is looked up as a standard attribute (such as ``gene_biotype`` or ``gene_name``). Works with both GTF and GFF3 files.
+* You can now annotate a table with a feature attribute drawn from a GTF/GFF annotation file (``Filter.annotate_from_gtf``), adding a new column that labels each gene (or transcript) with, for example, its biotype, chromosome, strand, or source. Features that are absent from the annotation file are left blank. Works with both GTF and GFF3 files.
+
 Changed
 *******
 * Sped up GO and KEGG enrichment analysis. P-value computation is now memoized across the many ontology terms that share the same gene counts (typically over 90% of terms in a GO run), and the ``elim`` propagation method no longer deep-copies the full annotation set on every run. Enrichment results are unchanged; the hypergeometric test and ``elim`` propagation benefit the most (up to ~20× and ~2-9× faster respectively on large ontologies).

--- a/rnalysis/filtering.py
+++ b/rnalysis/filtering.py
@@ -36,6 +36,7 @@ from rnalysis.utils import (clustering, differential_expression, generic,
                             parsing, settings, validation)
 from rnalysis.utils.generic import readable_name
 from rnalysis.utils.param_typing import (BIOTYPE_ATTRIBUTE_NAMES, BIOTYPES,
+                                         GTF_ATTRIBUTE_NAMES,
                                          DEFAULT_ORGANISMS, GO_EVIDENCE_TYPES,
                                          GO_QUALIFIERS, K_CRITERIA,
                                          LEGAL_GENE_LENGTH_METHODS,
@@ -186,7 +187,7 @@ class Filter:
 
         """
         legal_operations = {'filter': 'Filtering', 'normalize': 'Normalization', 'sort': 'Sorting',
-                            'transform': 'Transformation', 'translate': 'Translation'}
+                            'transform': 'Transformation', 'translate': 'Translation', 'annotate': 'Annotation'}
         assert isinstance(inplace, bool), "'inplace' must be True or False!"
         assert isinstance(opposite, bool), "'opposite' must be True or False!"
         assert printout_operation.lower() in legal_operations, \
@@ -961,6 +962,95 @@ class Filter:
             parsing.data_to_set(self.df.select(pl.first())))
         new_df = self.df.filter(pl.first().is_in(gene_names))
         return self._inplace(new_df, opposite, inplace, suffix)
+
+    @readable_name('Filter by feature attribute (based on a GTF/GFF file)')
+    def filter_by_gtf_attribute(self, gtf_path: Union[str, Path],
+                                attribute: Union[Literal[GTF_ATTRIBUTE_NAMES], str] = 'gene_biotype',
+                                value: Union[str, List[str]] = 'protein_coding',
+                                feature_type: Literal['gene', 'transcript'] = 'gene',
+                                opposite: bool = False, inplace: bool = True):
+        """
+        Filters the features in the table by any attribute described in a GTF/GFF annotation file, \
+        keeping only features whose attribute matches one of the specified values \
+        (for example: keep only genes on a specific chromosome or strand, from a specific source, \
+        or of a specific biotype). This is a generalization of `filter_biotype_from_gtf` to any GTF/GFF attribute.
+
+        :param gtf_path: Path to your GTF/GFF annotation file. The file should match the type of \
+        gene names/IDs you use in your table.
+        :type gtf_path: str or Path
+        :param attribute: name of the attribute to filter by. Standard column-9 attributes (such as 'gene_biotype', \
+        'gene_name', or any custom key in your file) are supported, as well as the reserved names 'chromosome', \
+        'source' and 'strand', which are read from the fixed columns of the annotation file.
+        :type attribute: str (default='gene_biotype')
+        :param value: the attribute value/values which will NOT be filtered out. For example, to keep only the \
+        features on chromosomes 'chr1' and 'chr2', set attribute='chromosome' and value=['chr1', 'chr2'].
+        :type value: str or list of strings
+        :param feature_type: determines whether the features/rows in your data table describe \
+        individual genes or transcripts.
+        :type feature_type: 'gene' or 'transcript' (default='gene')
+        :type opposite: bool
+        :param opposite: If True, the output of the filtering will be the OPPOSITE of the specified \
+        (instead of filtering out X, the function will filter out anything BUT X). \
+        If False (default), the function will filter as expected.
+        :type inplace: bool (default=True)
+        :param inplace: If True (default), filtering will be applied to the current Filter object. If False, \
+        the function will return a new Filter instance and the current instance will not be affected.
+        :return: If 'inplace' is False, returns a new and filtered instance of the Filter object.
+        """
+        value = parsing.data_to_set(value)
+        assert validation.isinstanceiter(value, str), "value must be a string or a list of strings!"
+        assert Path(gtf_path).exists(), "the given gtf path does not exist!"
+        suffix = f"_{attribute}_{'_'.join(sorted(value))}"
+
+        ref_srs = self._get_ref_srs_from_gtf(gtf_path, attribute, feature_type)
+        # feature IDs which remain after filtering are those whose attribute value is kept AND that appear in the table
+        gene_names = parsing.data_to_set(ref_srs.filter(pl.last().is_in(value))).intersection(
+            parsing.data_to_set(self.df.select(pl.first())))
+        new_df = self.df.filter(pl.first().is_in(gene_names))
+        return self._inplace(new_df, opposite, inplace, suffix)
+
+    @readable_name('Annotate table with a feature attribute (from a GTF/GFF file)')
+    def annotate_from_gtf(self, gtf_path: Union[str, Path],
+                          attribute: Union[Literal[GTF_ATTRIBUTE_NAMES], str] = 'gene_biotype',
+                          feature_type: Literal['gene', 'transcript'] = 'gene',
+                          column_name: Union[str, None] = None,
+                          inplace: bool = True):
+        """
+        Adds a new column to the table, annotating each feature with the value of a GTF/GFF attribute \
+        (for example: the biotype, chromosome, strand, or source of each gene). Features that are not found \
+        in the annotation file are annotated with a missing value.
+
+        :param gtf_path: Path to your GTF/GFF annotation file. The file should match the type of \
+        gene names/IDs you use in your table.
+        :type gtf_path: str or Path
+        :param attribute: name of the attribute to annotate with. Standard column-9 attributes (such as \
+        'gene_biotype', 'gene_name', or any custom key in your file) are supported, as well as the reserved names \
+        'chromosome', 'source' and 'strand', which are read from the fixed columns of the annotation file.
+        :type attribute: str (default='gene_biotype')
+        :param feature_type: determines whether the features/rows in your data table describe \
+        individual genes or transcripts.
+        :type feature_type: 'gene' or 'transcript' (default='gene')
+        :param column_name: the name of the new annotation column. If not specified, the attribute name is used. \
+        If a column with this name already exists in the table, it will be overwritten.
+        :type column_name: str or None (default=None)
+        :type inplace: bool (default=True)
+        :param inplace: If True (default), the annotation column will be added to the current Filter object. \
+        If False, the function will return a new Filter instance and the current instance will not be affected.
+        :return: If 'inplace' is False, returns a new and annotated instance of the Filter object.
+        """
+        assert Path(gtf_path).exists(), "the given gtf path does not exist!"
+        column_name = column_name if column_name else attribute
+        feature_id_col = self.df.columns[0]  # the table's feature-id (index) column; capture before dropping anything
+        assert column_name != feature_id_col, \
+            f"column_name '{column_name}' collides with the table's feature-id column; choose a different name."
+
+        ref_srs = self._get_ref_srs_from_gtf(gtf_path, attribute, feature_type)  # 2 columns: [feature_id, attr_value]
+        mapping = ref_srs.rename({ref_srs.columns[0]: '__feature_id__', ref_srs.columns[1]: column_name})
+        # overwrite an existing (non-index) column of the same name, then left-join so unmapped features get a null
+        base = self.df.drop(column_name) if column_name in self.df.columns else self.df
+        new_df = base.join(mapping, left_on=feature_id_col, right_on='__feature_id__', how='left')
+        return self._inplace(new_df, opposite=False, inplace=inplace, suffix=f'_annotated_{column_name}',
+                             printout_operation='annotate')
 
     @readable_name('Filter by feature biotype (based on a reference table)')
     def filter_biotype_from_ref_table(self, biotype: Union[Literal[BIOTYPES], str, List[str]] = 'protein_coding',

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -1997,6 +1997,7 @@ class FilterTabPage(TabPage):
                         'split_clicom': 'CLICOM (Ensemble)'}
     SUMMARY_FUNCS = {'describe', 'head', 'tail', 'biotypes_from_ref_table', 'biotypes_from_gtf', 'print_features'}
     GENERAL_FUNCS = {'concatenate', 'sort', 'sort_by_principal_component', 'transform', 'translate_gene_ids',
+                     'annotate_from_gtf',
                      'differential_expression_deseq2', 'differential_expression_deseq2_simplified', 'fold_change',
                      'average_replicate_samples', 'drop_columns',
                      'differential_expression_limma_voom', 'differential_expression_limma_voom_simplified',

--- a/rnalysis/utils/genome_annotation.py
+++ b/rnalysis/utils/genome_annotation.py
@@ -33,6 +33,10 @@ _FEATURE_IDX, _START_IDX, _END_IDX, _ATTR_IDX = 2, 3, 4, 8
 # Ensembl-style GFF3 gives IDs an SO-term prefix (``ID=gene:ENSG1``, ``Parent=transcript:ENST1``). Strip it so the
 # emitted gene/transcript IDs match a user's count table (WormBase-style bare IDs have no colon and are untouched).
 _SO_PREFIX_RE = r'^[A-Za-z_]+:'
+# Reserved attribute names that read a fixed, tab-separated GTF/GFF column (0-based) instead of a column-9 key=value
+# pair. GTF and GFF3 share this column layout, so these are format-agnostic. Everything not listed here is looked up
+# as a column-9 attribute (:func:`_extract_gtf_attribute` / :func:`_extract_gff3_attribute`).
+_FIXED_COLUMN_INDICES = {'chromosome': 0, 'seqname': 0, 'seqid': 0, 'source': 1, 'strand': 6}
 
 
 def parse_gtf_attributes(attr_str: str):
@@ -85,6 +89,19 @@ def _extract_gff3_attribute(attr_col: pl.Expr, key: str) -> pl.Expr:
 def _strip_so_prefix(expr: pl.Expr) -> pl.Expr:
     """Strip a leading GFF3 SO-term ``type:`` prefix from an ID expression (``transcript:ENST1`` -> ``ENST1``)."""
     return expr.str.replace(_SO_PREFIX_RE, '')
+
+
+def _attr_value_expr(fields_col: pl.Expr, attribute: str, file_type: Literal['gtf', 'gff3']) -> pl.Expr:
+    """Polars expression yielding the requested attribute's value per line.
+
+    Reserved names (``chromosome``/``source``/``strand``) read a fixed tab-separated column of the annotation
+    line; anything else is looked up as a column-9 key=value attribute in the file's format. ``fields_col`` is
+    the ``List[str]`` column of a line's tab-separated fields (see :func:`_scan_annotation_lines`).
+    """
+    if attribute in _FIXED_COLUMN_INDICES:
+        return fields_col.list.get(_FIXED_COLUMN_INDICES[attribute])
+    extract = _extract_gtf_attribute if file_type == 'gtf' else _extract_gff3_attribute
+    return extract(fields_col.list.get(_ATTR_IDX), attribute)
 
 
 def _scan_annotation_lines(path: Union[str, Path]) -> pl.LazyFrame:
@@ -302,7 +319,7 @@ def _map_gene_to_attr_gtf(fields: pl.DataFrame, attribute: str, feature_type: st
     # extract everything the reduction below reads, one row per line, in file order
     rows = fields.lazy().with_columns(
         pl.col('_fields').list.get(_ATTR_IDX).alias('_attr')).select(
-        _extract_gtf_attribute(pl.col('_attr'), attribute).alias('attr_value'),
+        _attr_value_expr(pl.col('_fields'), attribute, 'gtf').alias('attr_value'),
         _extract_gtf_attribute(pl.col('_attr'), 'gene_id').alias('gene_id'),
         _extract_gtf_attribute(pl.col('_attr'), 'transcript_id').alias('transcript_id'),
         _extract_gtf_attribute(pl.col('_attr'), 'gene_version').alias('gene_version'),
@@ -318,8 +335,8 @@ def _map_gene_to_attr_gtf(fields: pl.DataFrame, attribute: str, feature_type: st
             continue
         feature_name = None
         if feature_type == 'gene':
-            if row['gene_id'] is None:
-                raise KeyError('gene_id')
+            if row['gene_id'] is None:  # a fixed-column value present on a line that carries no gene_id -> skip
+                continue
             feature_id = row['gene_id'].split('.')[0] if split_ids else row['gene_id']
             if use_version and row['gene_version'] is not None:  # #152 bug #2: tolerate a missing version suffix
                 feature_id += '.' + row['gene_version']
@@ -331,8 +348,8 @@ def _map_gene_to_attr_gtf(fields: pl.DataFrame, attribute: str, feature_type: st
                 else:
                     continue
         else:
-            if row['transcript_id'] is None:
-                raise KeyError('transcript_id')
+            if row['transcript_id'] is None:  # e.g. a gene row when reading a fixed column in transcript mode -> skip
+                continue
             feature_id = row['transcript_id'].split('.')[0] if split_ids else row['transcript_id']
             if use_version and row['transcript_version'] is not None:  # #152 bug #2
                 feature_id += '.' + row['transcript_version']
@@ -357,21 +374,20 @@ def _map_gene_to_attr_gff3(fields: pl.DataFrame, attribute: str, feature_type: s
     # In GFF3 the attribute lives on the feature it describes: gene-level attrs on 'gene' rows, transcript-level
     # attrs on transcript rows. The feature id is that row's own (prefix-stripped) ID. GFF3 has no *_version attrs.
     role_features = ('gene',) if feature_type == 'gene' else TRANSCRIPT_FEATURE_NAMES
-    rows = fields.lazy().select(
-        pl.col('_fields').list.get(_FEATURE_IDX).alias('feature'),
-        pl.col('_fields').list.get(_ATTR_IDX).alias('_attr'),
-    ).filter(pl.col('feature').is_in(role_features)).select(
-        _extract_gff3_attribute(pl.col('_attr'), attribute).alias('attr_value'),
-        _strip_so_prefix(_extract_gff3_attribute(pl.col('_attr'), 'ID')).alias('feature_id'),
-        _extract_gff3_attribute(pl.col('_attr'), 'Name').alias('name'),
+    attr_col = pl.col('_fields').list.get(_ATTR_IDX)
+    rows = fields.lazy().filter(
+        pl.col('_fields').list.get(_FEATURE_IDX).is_in(role_features)).select(
+        _attr_value_expr(pl.col('_fields'), attribute, 'gff3').alias('attr_value'),
+        _strip_so_prefix(_extract_gff3_attribute(attr_col, 'ID')).alias('feature_id'),
+        _extract_gff3_attribute(attr_col, 'Name').alias('name'),
     ).collect()
 
     mapping = {}
     for row in rows.iter_rows(named=True):
         if row['attr_value'] is None:
             continue
-        if row['feature_id'] is None:
-            raise KeyError('ID')
+        if row['feature_id'] is None:  # a role row lacking an ID (e.g. a fixed-column read) -> skip, mirroring the GTF path
+            continue
         feature_id = row['feature_id'].split('.')[0] if split_ids else row['feature_id']
         if use_name:
             if row['name'] is None:

--- a/rnalysis/utils/param_typing.py
+++ b/rnalysis/utils/param_typing.py
@@ -33,6 +33,11 @@ BIOTYPE_ATTRIBUTE_NAMES = ('biotype', 'gene_biotype', 'transcript_biotype', 'gen
 # Feature-type keywords (column 3) that denote a transcript, across GTF and GFF3 conventions. Used to identify
 # transcript rows when parsing annotation files (mRNA/primary_transcript are the GFF3/GTF equivalents of 'transcript').
 TRANSCRIPT_FEATURE_NAMES = ('transcript', 'mRNA', 'primary_transcript')
+# Attribute names suggested in the GUI for filtering/annotating a table from a GTF/GFF file. Free text is also
+# allowed (used as Union[Literal[GTF_ATTRIBUTE_NAMES], str]). 'chromosome'/'source'/'strand' are reserved names that
+# read the fixed GTF/GFF columns; everything else is looked up as a column-9 key=value attribute.
+GTF_ATTRIBUTE_NAMES = ('gene_biotype', 'transcript_biotype', 'biotype', 'gene_name', 'gene_id', 'transcript_id',
+                       'chromosome', 'source', 'strand')
 
 GO_ASPECTS = ('biological_process', 'cellular_component', 'molecular_function')
 GO_EVIDENCE_TYPES = ('experimental', 'phylogenetic', 'computational', 'author', 'curator', 'electronic')

--- a/tests/test_files/counted_attributes.csv
+++ b/tests/test_files/counted_attributes.csv
@@ -1,0 +1,6 @@
+,cond1,cond2
+GENE1,10,20
+GENE2,5,6
+GENE3,7,8
+GENE4,3,4
+GENE5,1,2

--- a/tests/test_files/test_gff3_attributes.gff3
+++ b/tests/test_files/test_gff3_attributes.gff3
@@ -1,0 +1,9 @@
+##gff-version 3
+chr1	ensembl	gene	1000	2000	.	+	.	ID=gene:GENE1;biotype=protein_coding;Name=nameA
+chr1	ensembl	mRNA	1000	2000	.	+	.	ID=transcript:TX1;Parent=gene:GENE1;biotype=protein_coding;Name=txA
+chr2	havana	gene	3000	4000	.	-	.	ID=gene:GENE2;biotype=lincRNA;Name=nameB
+chr2	havana	mRNA	3000	4000	.	-	.	ID=transcript:TX2;Parent=gene:GENE2;biotype=lincRNA;Name=txB
+chrX	ensembl	gene	5000	6000	.	+	.	ID=gene:GENE3;biotype=protein_coding;Name=nameC
+chrX	ensembl	mRNA	5000	6000	.	+	.	ID=transcript:TX3;Parent=gene:GENE3;biotype=protein_coding;Name=txC
+chr2	havana	gene	7000	8000	.	-	.	ID=gene:GENE4;biotype=protein_coding;Name=nameD
+chr2	havana	mRNA	7000	8000	.	-	.	ID=transcript:TX4;Parent=gene:GENE4;biotype=protein_coding;Name=txD

--- a/tests/test_files/test_gtf_attributes.gtf
+++ b/tests/test_files/test_gtf_attributes.gtf
@@ -1,0 +1,8 @@
+chr1	ensembl	gene	1000	2000	.	+	.	gene_id "GENE1"; gene_biotype "protein_coding";
+chr1	ensembl	transcript	1000	2000	.	+	.	gene_id "GENE1"; transcript_id "TX1"; transcript_biotype "protein_coding";
+chr2	havana	gene	3000	4000	.	-	.	gene_id "GENE2"; gene_biotype "lincRNA";
+chr2	havana	transcript	3000	4000	.	-	.	gene_id "GENE2"; transcript_id "TX2"; transcript_biotype "lincRNA";
+chrX	ensembl	gene	5000	6000	.	+	.	gene_id "GENE3"; gene_biotype "protein_coding";
+chrX	ensembl	transcript	5000	6000	.	+	.	gene_id "GENE3"; transcript_id "TX3"; transcript_biotype "protein_coding";
+chr2	havana	gene	7000	8000	.	-	.	gene_id "GENE4"; gene_biotype "protein_coding";
+chr2	havana	transcript	7000	8000	.	-	.	gene_id "GENE4"; transcript_id "TX4"; transcript_biotype "protein_coding";

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -565,6 +565,91 @@ def test_countfilter_filter_biotype_from_gtf_opposite():
                            opposite=True)
 
 
+# ----------------------------------------------------------------------------------------------------------------------
+# #154: generic filter/annotate by any GTF/GFF attribute -- column-9 attributes (biotype, ...) AND fixed columns
+# (chromosome/source/strand). counted_attributes.csv has GENE1-4 (present in the GTF/GFF) plus GENE5 (absent).
+# ----------------------------------------------------------------------------------------------------------------------
+_ATTR_GTF = 'tests/test_files/test_gtf_attributes.gtf'
+_ATTR_GFF3 = 'tests/test_files/test_gff3_attributes.gff3'
+_ATTR_COUNTS = 'tests/test_files/counted_attributes.csv'
+
+
+def test_filter_by_gtf_attribute_reproduces_biotype_special_case():
+    # filter_by_gtf_attribute on the biotype attribute must reproduce the dedicated filter_biotype_from_gtf.
+    gtf = 'tests/test_files/test_gtf_for_biotypes.gtf'
+    counts = CountFilter('tests/test_files/counted_biotype.csv')
+    generic = counts.filter_by_gtf_attribute(gtf, 'gene_biotype', 'protein_coding', inplace=False)
+    special = counts.filter_biotype_from_gtf(gtf, 'protein_coding', inplace=False)
+    assert np.all(generic.df.sort(pl.first()) == special.df.sort(pl.first()))
+
+
+@pytest.mark.parametrize('path', [_ATTR_GTF, _ATTR_GFF3])
+@pytest.mark.parametrize('attribute,value,truth', [
+    ('chromosome', 'chr2', {'GENE2', 'GENE4'}),
+    ('chromosome', ['chr1', 'chrX'], {'GENE1', 'GENE3'}),
+    ('strand', '+', {'GENE1', 'GENE3'}),
+    ('source', 'havana', {'GENE2', 'GENE4'}),
+    ('gene_biotype', 'protein_coding', {'GENE1', 'GENE3', 'GENE4'}),
+])
+def test_filter_by_gtf_attribute(path, attribute, value, truth):
+    counts = CountFilter(_ATTR_COUNTS)
+    res = counts.filter_by_gtf_attribute(path, attribute, value, inplace=False)
+    assert parsing.data_to_set(res.df.select(pl.first())) == truth
+
+
+def test_filter_by_gtf_attribute_opposite_includes_unmapped():
+    # opposite returns every table feature NOT kept, including GENE5 which is absent from the annotation file.
+    counts = CountFilter(_ATTR_COUNTS)
+    res = counts.filter_by_gtf_attribute(_ATTR_GTF, 'chromosome', 'chr2', opposite=True, inplace=False)
+    assert parsing.data_to_set(res.df.select(pl.first())) == {'GENE1', 'GENE3', 'GENE5'}
+
+
+def _annotation_mapping(filter_obj, column_name):
+    return dict(zip(filter_obj.df.select(pl.first()).to_series().to_list(), filter_obj.df[column_name].to_list()))
+
+
+@pytest.mark.parametrize('path', [_ATTR_GTF, _ATTR_GFF3])
+def test_annotate_from_gtf_biotype(path):
+    counts = CountFilter(_ATTR_COUNTS)
+    res = counts.annotate_from_gtf(path, 'gene_biotype', inplace=False)
+    assert 'gene_biotype' in res.df.columns
+    # numeric columns of the original table are preserved
+    assert {'cond1', 'cond2'}.issubset(set(res.df.columns))
+    assert _annotation_mapping(res, 'gene_biotype') == {
+        'GENE1': 'protein_coding', 'GENE2': 'lincRNA', 'GENE3': 'protein_coding',
+        'GENE4': 'protein_coding', 'GENE5': None}  # GENE5 is absent from the annotation -> null
+
+
+def test_annotate_from_gtf_fixed_column_custom_name():
+    counts = CountFilter(_ATTR_COUNTS)
+    res = counts.annotate_from_gtf(_ATTR_GTF, 'chromosome', column_name='chrom', inplace=False)
+    assert 'chrom' in res.df.columns
+    assert _annotation_mapping(res, 'chrom') == {
+        'GENE1': 'chr1', 'GENE2': 'chr2', 'GENE3': 'chrX', 'GENE4': 'chr2', 'GENE5': None}
+
+
+def test_annotate_from_gtf_inplace_default_column_name():
+    counts = CountFilter(_ATTR_COUNTS)
+    assert counts.annotate_from_gtf(_ATTR_GFF3, 'chromosome', inplace=True) is None
+    assert _annotation_mapping(counts, 'chromosome') == {
+        'GENE1': 'chr1', 'GENE2': 'chr2', 'GENE3': 'chrX', 'GENE4': 'chr2', 'GENE5': None}
+
+
+def test_annotate_from_gtf_overwrites_existing_column():
+    counts = CountFilter(_ATTR_COUNTS)
+    res = counts.annotate_from_gtf(_ATTR_GTF, 'chromosome', column_name='cond2', inplace=False)
+    assert res.df.columns.count('cond2') == 1  # overwritten, not duplicated
+    assert _annotation_mapping(res, 'cond2') == {
+        'GENE1': 'chr1', 'GENE2': 'chr2', 'GENE3': 'chrX', 'GENE4': 'chr2', 'GENE5': None}
+
+
+def test_annotate_from_gtf_rejects_feature_id_column_name():
+    # naming the annotation column after the table's feature-id (index) column must not silently drop the IDs
+    counts = Filter.from_dataframe(pl.DataFrame({'gene': ['GENE1', 'GENE2'], 'cond1': [1.0, 2.0]}), 'annot_test')
+    with pytest.raises(AssertionError):
+        counts.annotate_from_gtf(_ATTR_GTF, 'chromosome', column_name='gene')
+
+
 def test_filter_by_attribute(basic_deseqfilter):
     truth = io.load_table('tests/test_files/test_deseq_filter_by_attr1.csv').sort(pl.first())
     d_notinplace = basic_deseqfilter.filter_by_attribute('attribute1', ref=__attr_ref__, inplace=False)

--- a/tests/test_genome_annotation.py
+++ b/tests/test_genome_annotation.py
@@ -485,3 +485,39 @@ def test_map_gene_to_attr_biotype_resolution_stays_within_feature_level(tmp_path
     # never the transcript's 'protein_coding'.
     assert map_gene_to_attr(_gene_type_with_transcript_biotype_gtf(tmp_path), 'gene_biotype', 'gene',
                             False, False, False) == {'G1': 'lincRNA'}
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# #154: fixed-column attribute reads. chromosome / source / strand are not column-9 key=value attributes -- they live in
+# the tab-separated columns (seqname/source/strand). map_gene_to_attr resolves these reserved names to those columns.
+# ----------------------------------------------------------------------------------------------------------------------
+ATTRIBUTES_GTF = 'tests/test_files/test_gtf_attributes.gtf'    # 4 genes across chr1/chr2/chrX, +/- strand, ensembl/havana
+ATTRIBUTES_GFF3 = 'tests/test_files/test_gff3_attributes.gff3'  # same content, with SO-term ID prefixes (gene:/transcript:)
+
+
+@pytest.mark.parametrize('attribute,truth', [
+    ('chromosome', {'GENE1': 'chr1', 'GENE2': 'chr2', 'GENE3': 'chrX', 'GENE4': 'chr2'}),
+    ('source', {'GENE1': 'ensembl', 'GENE2': 'havana', 'GENE3': 'ensembl', 'GENE4': 'havana'}),
+    ('strand', {'GENE1': '+', 'GENE2': '-', 'GENE3': '+', 'GENE4': '-'}),
+])
+def test_map_gene_to_attr_gtf_fixed_column_gene(attribute, truth):
+    assert map_gene_to_attr(ATTRIBUTES_GTF, attribute, 'gene', False, False, False) == truth
+
+
+@pytest.mark.parametrize('attribute,truth', [
+    ('chromosome', {'TX1': 'chr1', 'TX2': 'chr2', 'TX3': 'chrX', 'TX4': 'chr2'}),
+    ('strand', {'TX1': '+', 'TX2': '-', 'TX3': '+', 'TX4': '-'}),
+])
+def test_map_gene_to_attr_gtf_fixed_column_transcript(attribute, truth):
+    # Transcript mode must skip the gene rows (which carry a chromosome/strand but no transcript_id) rather than raise.
+    assert map_gene_to_attr(ATTRIBUTES_GTF, attribute, 'transcript', False, False, False) == truth
+
+
+@pytest.mark.parametrize('attribute,feature_type,truth', [
+    ('chromosome', 'gene', {'GENE1': 'chr1', 'GENE2': 'chr2', 'GENE3': 'chrX', 'GENE4': 'chr2'}),
+    ('source', 'gene', {'GENE1': 'ensembl', 'GENE2': 'havana', 'GENE3': 'ensembl', 'GENE4': 'havana'}),
+    ('strand', 'transcript', {'TX1': '+', 'TX2': '-', 'TX3': '+', 'TX4': '-'}),
+])
+def test_map_gene_to_attr_gff3_fixed_column(attribute, feature_type, truth):
+    # GFF3 IDs carry SO-term prefixes (gene:/transcript:); the fixed-column read still keys on the stripped IDs.
+    assert map_gene_to_attr(ATTRIBUTES_GFF3, attribute, feature_type, False, False, False) == truth


### PR DESCRIPTION
## What & why

**Goal-4 PR of epic #67** (Polars-native genome-annotation module). Closes #154.

The first Goal-4 feature on top of the annotation foundation (PR-A #162, PR-B #164, PR-C #193): filter **or** annotate a table by **any** GTF/GFF attribute, generalizing the biotype-only `filter_biotype_from_gtf`. Works on both GTF and GFF3.

## What's in it

**Two new public `Filter` methods** (inherited by CountFilter/DESeqFilter/FoldChangeFilter; GUI-reflected):

- `filter_by_gtf_attribute(gtf_path, attribute, value, feature_type='gene', opposite=False, inplace=True)` — keep only features whose attribute value is one of `value`. Mirrors `filter_biotype_from_gtf` exactly (same brute-force ID/name/version matching, `opposite`/`inplace`), so biotype filtering is now just its special case (verified by an equivalence test). Auto-routes to the GUI **Filter** tab.
- `annotate_from_gtf(gtf_path, attribute, feature_type='gene', column_name=None, inplace=True)` — add a column labelling each feature with an attribute value; features absent from the annotation get a null. Overwrites a same-named existing column, and refuses to collide with the feature-id (index) column. Routed to the GUI **General** tab (`FilterTabPage.GENERAL_FUNCS`).

**Attribute scope** — both standard column-9 attributes (`key "value"` / `key=value`: biotype, gene_name, any custom key) **and** the reserved fixed-column names `chromosome`/`source`/`strand`, which read the tab-separated columns of the annotation line. `genome_annotation.map_gene_to_attr` gained `_FIXED_COLUMN_INDICES` + `_attr_value_expr` for this; it now **skips** (rather than raises on) rows lacking the requested feature id, so fixed-column reads work in transcript mode. Well-formed GTF/GFF results are otherwise unchanged (96 genome-annotation tests + biotype/RPKM/TPM integration stay green).

**GUI** — `param_typing.GTF_ATTRIBUTE_NAMES` backs the attribute combo box (`Union[Literal[...], str]`, same pattern as the biotype attribute).

**Scope** — value-membership filtering only; numeric/predicate comparisons (coordinates, ranges) are split out to **#200** per review of the design.

## Verification

- Targeted `pytest tests/test_genome_annotation.py tests/test_filtering.py`: new fixed-column unit tests (GTF/GFF3, gene/transcript) + filter/annotate integration tests (col-9 biotype equivalence, chromosome/strand/source, GFF3, `opposite` including features absent from the GTF, column overwrite, index-name collision guard) all pass; 96 genome-annotation + broad filtering regression green. No R/Qt/network run locally (env has none) — CI covers those.
- An independent clean-context review found **no blocking issues** and one should-fix — `annotate_from_gtf` could drop the index column when `column_name` matched it — now fixed (capture the join key first + assert against the collision, with a regression test). It also prompted a GTF/GFF3 consistency tweak (skip id-less role rows uniformly).

## Compatibility

No existing public signatures changed; old serialized artifacts are unaffected. The only behavioural change to existing functions is internal robustness (malformed id-less rows are skipped rather than raising), which produces identical output on well-formed files. New capability documented under **Added** in `HISTORY.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
