### PR TITLE
test: skip live OrthoInspector tests when the service is unavailable

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -97,6 +97,20 @@ def is_ensembl_available():
     return True
 
 
+def is_orthoinspector_available():
+    # OrthoInspector's per-database `orthologs` endpoints are the flaky part -- the `databases`/`species`
+    # endpoints can respond while these time out (the real-world outage this guard exists for). Probe the
+    # exact capability the live tests need, mirroring OrthoInspectorOrthologMapper's URL and timeout.
+    url = 'https://api.bigest-icube.fr/orthoinspector/Eukaryota2016/species/6239/orthologs/6238'
+    try:
+        req = requests.get(url, timeout=(10, 30))
+    except requests.exceptions.RequestException:
+        return False
+    if str(req.status_code)[0] in ['4', '5']:
+        return False
+    return True
+
+
 def is_phylomedb_available():
     try:
         host = socket.gethostbyname('ftp.phylomedb.org')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,12 +9,13 @@ from rnalysis.utils import io
 from rnalysis.utils.io import *
 from rnalysis.utils.io import _ensembl_lookup_post_request, _format_ids_iter
 from tests import (is_ensembl_available, is_phylomedb_available,
-                   is_uniprot_available, is_pantherdb_available)
+                   is_uniprot_available, is_pantherdb_available, is_orthoinspector_available)
 
 ENSEMBL_AVAILABLE = is_ensembl_available()
 UNIPROT_AVAILABLE = is_uniprot_available()
 PHYLOMEDB_AVAILABLE = is_phylomedb_available()
 PANTHERDB_AVAILABLE = is_pantherdb_available()
+ORTHOINSPECTOR_AVAILABLE = is_orthoinspector_available()
 
 
 class MockResponse(object):
@@ -1704,12 +1705,14 @@ class TestOrthoInspectorOrthologMapper:
         assert filename == 'orthoinspector_organism2_organism1.json'
 
     # Test the get_databases method
+    @pytest.mark.skipif(not ORTHOINSPECTOR_AVAILABLE, reason='OrthoInspector API is not available at the moment')
     def test_get_databases(self, ortholog_mapper):
         databases = ortholog_mapper.get_databases()
         assert isinstance(databases, frozenset)
         assert len(databases) >= 4  # the current number of OrthoInspector databases
 
     # Test the get_database_organisms method
+    @pytest.mark.skipif(not ORTHOINSPECTOR_AVAILABLE, reason='OrthoInspector API is not available at the moment')
     def test_get_database_organisms(self, ortholog_mapper):
         db_organisms = ortholog_mapper.get_database_organisms()
         assert isinstance(db_organisms, dict)
@@ -1722,6 +1725,7 @@ class TestOrthoInspectorOrthologMapper:
     # TestEnsemblOrthologMapper). OrthoInspector rebuilds its databases periodically, which can
     # change which accession is picked as "first"/"last"/"random" even though the mapper's own
     # logic hasn't changed, so we check structural invariants instead.
+    @pytest.mark.skipif(not ORTHOINSPECTOR_AVAILABLE, reason='OrthoInspector API is not available at the moment')
     @pytest.mark.parametrize('database,non_unique_mode', [
         ('auto', 'first'),
         ('Eukaryota2016', 'last'),


### PR DESCRIPTION
## What

The live-network OrthoInspector tests (`TestOrthoInspectorOrthologMapper`) hard-fail in CI whenever OrthoInspector has an outage. In [this run](https://github.com/GuyTeichman/RNAlysis/actions/runs/30796123703/job/93290800980) all three databases' `orthologs` endpoints timed out and the mapper raised:

```
RuntimeError: All attempted databases (Eukaryota2023, Eukaryota2019, Eukaryota2016) failed to respond.
```

That is an external-service outage, not a regression, so the tests should **skip** — the way our UniProt / Ensembl / PANTHER / PhylomeDB live tests already do.

## Changes

- **`tests/__init__.py`** — add `is_orthoinspector_available()`, mirroring the existing `is_*_available()` probes.
- **`tests/test_io.py`** — wire `ORTHOINSPECTOR_AVAILABLE` and gate the three live tests (`test_get_databases`, `test_get_database_organisms`, `test_get_orthologs`) with `@pytest.mark.skipif(not ORTHOINSPECTOR_AVAILABLE, reason='OrthoInspector API is not available at the moment')`.

## Why the probe hits `orthologs`, not just `/databases`

In the observed outage the `/databases` and `/species` endpoints responded fine (the mapper got as far as selecting `valid_dbs`) and only the per-database `orthologs` endpoints timed out. A host-only ping would have reported "available" and the tests would still have failed, so the probe exercises the exact `orthologs` capability the tests depend on, using the same URL and timeout as `OrthoInspectorOrthologMapper`.

## Not gated on purpose

The mocked tests in the class (constructor, `translate_ids`, cache filename, retry-policy, API-URL-not-deprecated, and the timeout/fallback test) touch no network, so they stay active and keep guarding the mapper logic even when OrthoInspector is down.

## Testing

- Full class against the live service: **13 passed** (one run showed `Eukaryota2023` read-timing-out with a successful fallback to another DB — the exact flakiness this guards against).
- Probe contract verified: `RequestException` -> `False`, `503` -> `False`, `200` -> `True` (down => skip, up => run).
- The skip reason contains "available", so conftest's tiering heuristic keeps these tests classified as `integration_net` (no tier change).

Test-only change: no product code and no numerical output changed, so no `HISTORY.rst` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
