### PR TITLE
ci: drop Windows pagefile guard & pin setup-homebrew (reduce CI warnings)

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -83,14 +83,6 @@ jobs:
             # the culprit. No effect on runs where this env var is unset (e.g. local runs).
             PYTEST_CRASH_BREADCRUMB: ${{ github.workspace }}/pytest_last_test.txt
         steps:
-            -   name: Configure pagefile
-                if: runner.os == 'Windows'
-                uses: al-cheb/configure-pagefile-action@v1.5
-
-            -   name: Set up pagefile
-                if: runner.os == 'Windows'
-                run: |
-                    (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize
             -   name: Get repository
                 uses: actions/checkout@v7
                 with:
@@ -150,7 +142,9 @@ jobs:
                         r-libs-${{ runner.os }}-R4.4-
             -   name: Install homebrew on Linux
                 if: runner.os == 'Linux'
-                uses: Homebrew/actions/setup-homebrew@master
+                # Pinned to a commit SHA (tag 2026.07.10.1): the moving `@master` ref is deprecated
+                # and warned on every run ("the master branch sync will stop"). Dependabot bumps this.
+                uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c
             -   name: Install cURL on Linux
                 if: runner.os == 'Linux'
                 run: sudo apt-get install libcurl4-openssl-dev


### PR DESCRIPTION
## What

Two CI-warning cleanups, stacked on top of #202 so the Windows observation isn't muddied by flaky OrthoInspector failures:

1. **Remove the Windows pagefile guard** (`al-cheb/configure-pagefile-action` + the `AllocatedBaseSize` readout). Added in 2023 during a heavy test-suite expansion, it emits a cosmetic-but-**red** `SetPageFileSize ... "The operation completed successfully"` error annotation on every Windows run. `v1.5` is already the latest release and still throws it, so dropping the action is the only way to clear the annotation.

2. **Pin `Homebrew/actions/setup-homebrew`** from the deprecated moving `@master` ref to the GitHub-recommended commit SHA `1f8e202...` (tag `2026.07.10.1`), silencing the per-run deprecation warning.

## Why this is an experiment

The pagefile guard has been **Windows-only for ~3 years**; Linux and macOS run fine with no swap/pagefile bump. The hypothesis is that the memory pressure that motivated it in 2023 has since been optimized out of the codebase. **This PR is how we test that.**

## What to watch

The **Windows** jobs' `unit → integration_tools → e2e` tiers. If the pagefile was load-bearing, OOM there tends to surface as the flaky access-violation crash rather than a clean OOM. If Windows goes red, revert the pagefile removal — the `setup-homebrew` pin is independent and safe to keep either way.

## Deliberately not addressed (upstream / environmental)

- **Node 20 deprecation** warnings (`install-llvm-action`, `setup-graphviz`, `setup-qt-libs`): all three are still `node20` at their latest tags, and `setup-qt-libs` is archived (read-only). Bumping versions won't silence them; Dependabot will pick up any real `node24` releases.
- **macOS `aws/tap` trust** and **Linux Homebrew sandbox/bubblewrap** warnings: GitHub-runner-image / Homebrew-on-Linux noise, not our workflow config.

---

**Base:** #202 (`fix/skip-orthoinspector-tests-when-down`). Retarget to `development` once #202 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
