### PR TITLE
GUI UX: reframe Optional parameter widget to a positive 'Set a value' pattern (#210)

### DIFF
--- a/rnalysis/gui/gui_widgets.py
+++ b/rnalysis/gui/gui_widgets.py
@@ -1280,47 +1280,49 @@ class OptionalWidget(QtWidgets.QWidget):
     __slots__ = {'layout': 'layout',
                  'other': 'other widget',
                  'default': 'default value',
-                 'checkbox': 'disable checkbox'}
+                 'checkbox': 'set-value checkbox'}
 
     def __init__(self, other: QtWidgets.QWidget, default=EMPTY, parent=None):
         super().__init__(parent)
         self.layout = QtWidgets.QHBoxLayout(self)
         self.other = other
         self.default = default
-        self.checkbox = QtWidgets.QCheckBox('Disable this parameter?')
+        self.checkbox = QtWidgets.QCheckBox('Set a value')
         self.toggled = self.checkbox.toggled
 
         self.init_ui()
 
     def clear(self):
-        self.checkbox.setChecked(False)
+        self.checkbox.setChecked(True)
         try:
             self.other.clear()
         except AttributeError:
             pass
 
     def init_ui(self):
-        self.toggled.connect(self.other.setDisabled)
+        self.toggled.connect(self.other.setEnabled)
         self.layout.addWidget(self.checkbox)
         self.layout.addWidget(self.other)
-        if self.default is None:
-            self.checkbox.setChecked(True)
+        # checked = provide a value (inner enabled); unchecked = use default/None (inner disabled).
+        # A default of None means "leave unset"; any other default (incl. EMPTY) means "provide a value".
+        self.checkbox.setChecked(self.default is not None)
+        self.check_other()
 
     def check_other(self):
-        self.other.setDisabled(self.checkbox.isChecked())
+        self.other.setEnabled(self.checkbox.isChecked())
 
     def value(self):
         if self.checkbox.isChecked():
-            return None
-        return get_val_from_widget(self.other)
+            return get_val_from_widget(self.other)
+        return None
 
     def setValue(self, val):
         if val is None:
-            self.checkbox.setChecked(True)
+            self.checkbox.setChecked(False)
         else:
             try:
                 set_widget_value(self.other, val)
-                self.checkbox.setChecked(False)
+                self.checkbox.setChecked(True)
             except AttributeError:
                 raise ValueError(f'Unable to set default value of {type(self.other)} to {val}')
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -206,6 +206,87 @@ def test_get_val_from_widget_nonnative_types(qtbot, widget_class, keyboard_inter
     assert get_val_from_widget(widget) == expected_val
 
 
+def test_OptionalWidget_label_is_positive(qtbot):
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=QtWidgets.QLineEdit())
+    assert widget.checkbox.text() == 'Set a value'
+
+
+def test_OptionalWidget_default_none_is_unchecked_and_disabled(qtbot):
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=QtWidgets.QLineEdit(), default=None)
+    assert not widget.checkbox.isChecked()
+    assert not widget.other.isEnabled()
+    assert widget.value() is None
+
+
+def test_OptionalWidget_default_empty_is_checked_and_enabled(qtbot):
+    inner = QtWidgets.QLineEdit()
+    inner.setText('preset')
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=inner)
+    assert widget.checkbox.isChecked()
+    assert widget.other.isEnabled()
+    assert widget.value() == 'preset'
+
+
+def test_OptionalWidget_checked_provides_value_unchecked_returns_none(qtbot):
+    inner = QtWidgets.QLineEdit()
+    inner.setText('abc')
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=inner, default=None)
+    # start unchecked -> use default/None, inner disabled
+    assert not widget.other.isEnabled()
+    assert widget.value() is None
+    # check -> provide value, inner enabled
+    widget.checkbox.setChecked(True)
+    assert widget.other.isEnabled()
+    assert widget.value() == 'abc'
+    # uncheck -> back to None, inner disabled
+    widget.checkbox.setChecked(False)
+    assert not widget.other.isEnabled()
+    assert widget.value() is None
+
+
+def test_OptionalWidget_check_other_follows_checkbox(qtbot):
+    inner = QtWidgets.QLineEdit()
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=inner, default=None)
+    widget.checkbox.setChecked(True)
+    widget.check_other()
+    assert widget.other.isEnabled()
+    widget.checkbox.setChecked(False)
+    widget.check_other()
+    assert not widget.other.isEnabled()
+
+
+@pytest.mark.parametrize('val', [None, 'text', ''])
+def test_OptionalWidget_setValue_value_roundtrip(qtbot, val):
+    qtbot, widget = widget_setup(qtbot, OptionalWidget, other=QtWidgets.QLineEdit())
+    widget.setValue(val)
+    assert widget.value() == val
+    if val is None:
+        assert not widget.checkbox.isChecked()
+        assert not widget.other.isEnabled()
+    else:
+        assert widget.checkbox.isChecked()
+        assert widget.other.isEnabled()
+
+
+@pytest.mark.parametrize('param_type,default,expected', [
+    (Union[str, None], None, None),
+    (Union[str, None], 'text', 'text'),
+    (Union[int, None], None, None),
+    (Union[int, None], 5, 5),
+    (Union[float, None], -0.5, -0.5),
+])
+def test_OptionalWidget_param_to_widget_value_matches_default(qtbot, param_type, default, expected):
+    param = NewParam(param_type, default)
+    widget = param_to_widget(param, 'name')
+    widget.show()
+    qtbot.add_widget(widget)
+    # returned value is identical to the serialized default (back-compat invariant)
+    assert widget.value() == expected
+    # None default -> unset (unchecked/disabled); concrete default -> set (checked/enabled)
+    assert widget.checkbox.isChecked() == (default is not None)
+    assert widget.other.isEnabled() == (default is not None)
+
+
 @pytest.mark.parametrize("widget_class,default,excepted_val_empty,expected_val,kwargs", [
     (QMultiSpinBox, [0, 2, 3], 0, [0, 2, 3], {}),
     (QMultiDoubleSpinBox, [0.1, 3.2, 5], 0.0, [0.1, 3.2, 5], {}),


### PR DESCRIPTION
## Summary

Reframes the `Optional[T]` / `Union[T, None]` parameter widget (`OptionalWidget`) from a
confusing double-negative into a positive affordance.

Before: a checkbox labeled **"Disable this parameter?"** — to *provide* a value the user had
to *uncheck* "disable" (and in FASTQ/external windows it read as "Disable input?" next to a
"Set input" button).

After: a checkbox labeled **"Set a value"** with intuitive polarity:

- **Checked** = provide the value (inner widget enabled).
- **Unchecked** = use default / None (inner widget disabled).
- default `None` -> unchecked, inner disabled, `value()` returns `None`.
- default concrete value (or no default / `EMPTY`) -> checked, inner enabled and set to that value.

## Why this is safe (hard constraints)

This is an **interaction/label change only**. The values the widget returns are identical to
before:

- `value()` returns `None` when unset and the inner value when set (the two branches were
  simply swapped along with the checkbox polarity).
- `setValue(None)` leaves it unset; `setValue(concrete)` sets and enables the inner widget.
- Serialized parameter values (None or a concrete value) are unchanged, so **saved sessions,
  Pipelines, and exported parameters round-trip byte-for-byte**.

### Consumers audited

- `FuncTypeStack.get_function_predecessors` (`gui.py`) reads `widget.other.isEnabled()`.
  "Enabled" means "value is provided" in **both** the old and new polarity, so this reader is
  correct unchanged.
- `connect_widget` in `gui.py` and `gui_windows.py` only recurses into `widget.other` — polarity-agnostic.
- `get_val_from_widget` / `set_widget_value` go through `value()` / `setValue()` — semantics preserved.
- `param_to_widget` wires `widget.toggled` to refresh actions that react to any toggle (they do
  not read the boolean), so the flipped polarity is fine.
- No code outside the class reads `OptionalWidget.checkbox` state directly.

## Tests

Added TDD coverage in `tests/test_gui_widgets.py` (written failing first, then made to pass):

- positive label text;
- default `None` -> unchecked/disabled/`value()==None`;
- default `EMPTY`/concrete -> checked/enabled/`value()==inner`;
- toggle wiring flips enable state and value between the inner value and `None`;
- `check_other()` follows the checkbox;
- `setValue`/`value` round-trips for `None`, a concrete string, and `''`;
- `param_to_widget` value equals the serialized default and `other.isEnabled()` tracks
  "value provided" for both `None` and concrete defaults.

Ran on Windows (conda `rnalysis`, PyQt6):

- `tests/test_gui_widgets.py` — 437 passed.
- `tests/test_gui.py -k "FuncTypeStack or apply_pipeline or get_analysis_params or predecessor
  or import_pipeline or export_pipeline"` — 58 passed (exercises the audited consumers,
  including predecessor detection and Pipeline import/export).

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1K2LQyVMdofggdMAEp9y
