### PR TITLE
GUI UX: humanize parameter labels (display-only) with override decorator

### DIFF
--- a/rnalysis/fastq.py
+++ b/rnalysis/fastq.py
@@ -22,7 +22,7 @@ from tqdm.auto import tqdm
 from rnalysis import filtering
 from rnalysis.utils import (feature_counting, generic, genome_annotation,
                             installs, io, parsing, validation)
-from rnalysis.utils.generic import readable_name
+from rnalysis.utils.generic import param_readable_names, readable_name
 from rnalysis.utils.param_typing import (LEGAL_ALIGNMENT_SUFFIXES,
                                          LEGAL_BOWTIE2_MODES,
                                          LEGAL_BOWTIE2_PRESETS,
@@ -2041,6 +2041,7 @@ def _sum_transcripts_to_genes(tpm: pl.DataFrame, counts: pl.DataFrame, gtf_path:
 
 @_func_type('single')
 @readable_name('CutAdapt (single-end reads)')
+@param_readable_names({'trim_n': 'Trim ambiguous (N) bases'})
 def trim_adapters_single_end(fastq_folder: Union[str, Path], output_folder: Union[str, Path],
                              three_prime_adapters: Union[None, str, List[str]],
                              five_prime_adapters: Union[None, str, List[str]] = None,
@@ -2158,6 +2159,7 @@ def trim_adapters_single_end(fastq_folder: Union[str, Path], output_folder: Unio
 
 @_func_type('paired')
 @readable_name('CutAdapt (paired-end reads)')
+@param_readable_names({'trim_n': 'Trim ambiguous (N) bases'})
 def trim_adapters_paired_end(r1_files: List[Union[str, Path]], r2_files: List[Union[str, Path]],
                              output_folder: Union[str, Path],
                              three_prime_adapters_r1: Union[None, str, List[str]],

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -795,9 +795,10 @@ class EnrichmentWindow(gui_widgets.MinMaxDialog):
         gui_widgets.clear_layout(self.plot_grid)
 
         i = 0
+        func = self.get_current_func()
         for name, (param, desc) in self.plot_signature.items():
             self.plot_widgets[name] = gui_widgets.param_to_widget(param, name)
-            label = QtWidgets.QLabel(f'{name}:', self.plot_widgets[name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.plot_widgets[name])
             label.setToolTip(desc)
             help_button = gui_widgets.HelpButton()
             self.plot_grid.addWidget(label, i, 0)
@@ -814,9 +815,10 @@ class EnrichmentWindow(gui_widgets.MinMaxDialog):
         gui_widgets.clear_layout(self.parameter_grid)
 
         i = 0
+        func = self.get_current_func()
         for name, (param, desc) in self.parameters_signature.items():
             self.parameter_widgets[name] = gui_widgets.param_to_widget(param, name)
-            label = QtWidgets.QLabel(f'{name}:', self.parameter_widgets[name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.parameter_widgets[name])
             label.setToolTip(desc)
             help_button = gui_widgets.HelpButton()
             self.parameter_grid.addWidget(help_button, i, 2)
@@ -848,10 +850,11 @@ class EnrichmentWindow(gui_widgets.MinMaxDialog):
         self.stats_grid.addWidget(self.stats_widgets['stats_radiobox'], 0, 0, 3, 2)
 
         i = 0
+        func = self.get_current_func()
         for name, (param, desc) in self.stats_signature.items():
             if name in self.STATISTICAL_TEST_ARGS[prev_test]:
                 self.stats_widgets[name] = gui_widgets.param_to_widget(param, name)
-                label = QtWidgets.QLabel(f'{name}:', self.stats_widgets[name])
+                label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.stats_widgets[name])
                 label.setToolTip(desc)
                 help_button = gui_widgets.HelpButton()
                 self.stats_grid.addWidget(help_button, i, 4)
@@ -1123,12 +1126,14 @@ class SetOperationWindow(gui_widgets.MinMaxDialog):
 
         chosen_func_name = self.get_current_func_name()
         signature = generic.get_method_signature(chosen_func_name, filtering.Filter)
+        func = getattr(filtering.Filter, chosen_func_name, None)
         i = 0
         for name, param in signature.items():
             if name in self.EXCLUDED_PARAMS:
                 continue
             self.parameter_widgets[name] = gui_widgets.param_to_widget(param, name)
-            self.parameter_grid.addWidget(QtWidgets.QLabel(f'{name}:', self.parameter_widgets[name]), i, 0)
+            self.parameter_grid.addWidget(
+                QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.parameter_widgets[name]), i, 0)
             self.parameter_grid.addWidget(self.parameter_widgets[name], i, 1)
             if chosen_func_name == 'majority_vote_intersection':
                 self.parameter_widgets[name].valueChanged.connect(self._majority_vote_intersection)
@@ -1366,13 +1371,15 @@ class SetVisualizationWindow(gui_widgets.MinMaxDialog):
 
         chosen_func_name = self.get_current_func_name()
         signature = generic.get_method_signature(chosen_func_name, enrichment)
+        func = getattr(enrichment, chosen_func_name, None)
         i = 0
         for name, param in signature.items():
             if name in self.EXCLUDED_PARAMS:
                 continue
             self.parameter_widgets[name] = gui_widgets.param_to_widget(param, name,
                                                                        actions_to_connect=self.create_canvas)
-            self.parameter_grid.addWidget(QtWidgets.QLabel(f'{name}:', self.parameter_widgets[name]), i, 0)
+            self.parameter_grid.addWidget(
+                QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.parameter_widgets[name]), i, 0)
             self.parameter_grid.addWidget(self.parameter_widgets[name], i, 1)
             i += 1
 
@@ -1913,6 +1920,7 @@ class FuncTypeStack(QtWidgets.QWidget):
 
         signature = generic.get_method_signature(chosen_func_name, self.filter_obj)
         desc, param_desc = io.get_method_docstring(chosen_func_name, self.filter_obj)
+        func = getattr(self.filter_obj, chosen_func_name, None)
         self.func_combo.setToolTip(desc)
         self.func_help_button.set_param_help(self.get_function_readable_name(), desc)
 
@@ -1923,7 +1931,7 @@ class FuncTypeStack(QtWidgets.QWidget):
             self.parameter_widgets[name] = gui_widgets.param_to_widget(param, name, pipeline_mode=self.pipeline_mode)
             self.connect_widget(self.parameter_widgets[name])
 
-            label = QtWidgets.QLabel(f'{name}:', self.parameter_widgets[name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.parameter_widgets[name])
             if name in param_desc:
                 label.setToolTip(param_desc[name])
                 help_button = gui_widgets.HelpButton()
@@ -2144,13 +2152,14 @@ class FilterTabPage(TabPage):
         filter_obj_type = FILTER_OBJ_TYPES[self.basic_widgets['table_type_combo'].currentText()]
         signature = generic.get_method_signature(func_name, filter_obj_type)
         desc, param_desc = io.get_method_docstring(func_name, filter_obj_type)
+        func = getattr(filter_obj_type, func_name, None)
         self.basic_widgets['table_type_combo'].setToolTip(desc)
         i = 1
         for name, param in signature.items():
             if name in INIT_EXCLUDED_PARAMS:
                 continue
             self.basic_param_widgets[name] = gui_widgets.param_to_widget(param, name)
-            label = QtWidgets.QLabel(f'{name}:', self.basic_param_widgets[name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.basic_param_widgets[name])
             if name in param_desc:
                 label.setToolTip(param_desc[name])
                 help_button = gui_widgets.HelpButton()
@@ -2773,13 +2782,14 @@ class MultiOpenWindow(QtWidgets.QDialog):
         filter_obj_type = FILTER_OBJ_TYPES[self.table_types[file].currentText()]
         signature = generic.get_method_signature(func_name, filter_obj_type)
         desc, param_desc = io.get_method_docstring(func_name, filter_obj_type)
+        func = getattr(filter_obj_type, func_name, None)
         self.table_types[file].setToolTip(desc)
         i = 1
         for name, param in signature.items():
             if name in INIT_EXCLUDED_PARAMS:
                 continue
             self.kwargs_widgets[file][name] = gui_widgets.param_to_widget(param, name)
-            label = QtWidgets.QLabel(f'{name}:', self.kwargs_widgets[file][name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, func)}:', self.kwargs_widgets[file][name])
             if name in param_desc:
                 label.setToolTip(param_desc[name])
                 help_button = gui_widgets.HelpButton()

--- a/rnalysis/gui/gui_windows.py
+++ b/rnalysis/gui/gui_windows.py
@@ -697,7 +697,7 @@ class FuncExternalWindow(gui_widgets.MinMaxDialog):
             self.param_widgets[name] = gui_widgets.param_to_widget(param, name)
             self.connect_widget(self.param_widgets[name])
 
-            label = QtWidgets.QLabel(f'{name}:', self.param_widgets[name])
+            label = QtWidgets.QLabel(f'{generic.get_param_readable_name(name, self.func)}:', self.param_widgets[name])
             label.setToolTip(this_desc)
             help_button = gui_widgets.HelpButton()
             self.param_grid.addWidget(help_button, i, 2)

--- a/rnalysis/utils/generic.py
+++ b/rnalysis/utils/generic.py
@@ -8,7 +8,7 @@ import warnings
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Callable, Tuple, Union
+from typing import Callable, Dict, Tuple, Union
 
 import joblib
 import matplotlib.collections
@@ -49,6 +49,113 @@ def readable_name(name: str):
         return item
 
     return decorator
+
+
+def param_readable_names(names: Dict[str, str]):
+    """
+    Decorator that attaches human-readable display labels for specific parameters of a function.
+
+    The mapping is stored on the function's ``readable_param_names`` attribute (mirroring how
+    :func:`readable_name` sets ``readable_name``) and is used by :func:`get_param_readable_name`
+    to override the auto-humanized label for parameters that do not humanize well. This is
+    display-only: it never changes the actual parameter names used when calling the function.
+
+    :param names: mapping of raw (snake_case) parameter names to their human-readable labels.
+    :type names: dict of str to str
+    """
+
+    def decorator(item):
+        item.readable_param_names = names
+        return item
+
+    return decorator
+
+
+# Domain acronyms / tokens preserved verbatim when auto-humanizing parameter labels.
+# Keyed by the lowercase snake_case token; the value is the exact display form.
+PARAM_LABEL_ACRONYMS = {
+    'go': 'GO',
+    'kegg': 'KEGG',
+    'pca': 'PCA',
+    'fdr': 'FDR',
+    'id': 'ID',
+    'ids': 'IDs',
+    'rna': 'RNA',
+    'mrna': 'mRNA',
+    'dna': 'DNA',
+    'deseq2': 'DESeq2',
+    'sam': 'SAM',
+    'bam': 'BAM',
+    'fastq': 'FASTQ',
+    'gtf': 'GTF',
+    'gff': 'GFF',
+    'utr': 'UTR',
+    'cpm': 'CPM',
+    'tpm': 'TPM',
+    'rpkm': 'RPKM',
+    'fpkm': 'FPKM',
+    'padj': 'padj',
+    'clicom': 'CLICOM',
+    'hdbscan': 'HDBSCAN',
+    'umap': 'UMAP',
+    'ncbi': 'NCBI',
+    'url': 'URL',
+    'csv': 'CSV',
+}
+
+# Whole parameter-name overrides that auto-humanization handles poorly but which apply
+# regardless of the containing function (per-function overrides take precedence over these).
+PARAM_LABEL_SPECIAL_NAMES = {
+    'n_components': 'Number of components',
+}
+
+
+def _humanize_param_name(param_name: str) -> str:
+    words = []
+    first = True
+    for token in param_name.split('_'):
+        if token == '':
+            continue
+        lower = token.lower()
+        if lower in PARAM_LABEL_ACRONYMS:
+            words.append(PARAM_LABEL_ACRONYMS[lower])
+        elif first:
+            words.append(token.capitalize())
+        else:
+            words.append(lower)
+        first = False
+    if not words:
+        return param_name
+    return ' '.join(words)
+
+
+def get_param_readable_name(param_name: str, func: Union[Callable, None] = None) -> str:
+    """
+    Return a human-readable display label for a function parameter (display-only).
+
+    Resolution order:
+
+    1. a per-function override declared via :func:`param_readable_names`, if ``func`` is given
+       and declares a label for ``param_name``;
+    2. a global whole-name special case (:data:`PARAM_LABEL_SPECIAL_NAMES`);
+    3. auto-humanization: split on ``_``, sentence-case the words and join with spaces, while
+       preserving known domain acronyms (:data:`PARAM_LABEL_ACRONYMS`).
+
+    The raw ``param_name`` is never modified for use as an actual keyword argument; this only
+    affects what the GUI shows the user.
+
+    :param param_name: the raw (snake_case) parameter name from the function signature.
+    :type param_name: str
+    :param func: the function the parameter belongs to, used to look up per-function overrides.
+    :type func: callable or None
+    """
+    if func is not None:
+        overrides = getattr(func, 'readable_param_names', None)
+        if overrides is not None and param_name in overrides:
+            return overrides[param_name]
+    if param_name in PARAM_LABEL_SPECIAL_NAMES:
+        return PARAM_LABEL_SPECIAL_NAMES[param_name]
+    return _humanize_param_name(param_name)
 
 
 class TemporaryMatplotlibBackend:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -224,6 +224,74 @@ def test_get_method_readable_name():
     assert get_method_readable_name(func2) == "readable name"
 
 
+def test_param_readable_names_decorator_sets_attribute():
+    mapping = {'trim_n': 'Trim ambiguous (N) bases', 'drop_columns': 'Columns to drop'}
+
+    @param_readable_names(mapping)
+    def func(trim_n=True, drop_columns=None):
+        return trim_n, drop_columns
+
+    assert func.readable_param_names == mapping
+    # the decorator must not alter the function's behavior
+    assert func(False, ['a']) == (False, ['a'])
+
+
+@pytest.mark.parametrize("param_name,expected", [
+    ('fastq_folder', 'FASTQ folder'),
+    ('three_prime_adapters', 'Three prime adapters'),
+    ('minimum_read_length', 'Minimum read length'),
+    ('power_transform', 'Power transform'),
+    ('drop_columns', 'Drop columns'),
+    ('trim_n', 'Trim n'),
+    ('single', 'Single'),
+    ('go_id', 'GO ID'),
+    ('kegg_pathways', 'KEGG pathways'),
+    ('gene_ids', 'Gene IDs'),
+    ('rna_type', 'RNA type'),
+    ('mrna_length', 'mRNA length'),
+    ('use_pca', 'Use PCA'),
+    ('fdr_level', 'FDR level'),
+    ('deseq2_normalization', 'DESeq2 normalization'),
+    ('sam_path', 'SAM path'),
+    ('bam_index', 'BAM index'),
+    ('fastq_to_sam', 'FASTQ to SAM'),
+    ('padj_threshold', 'padj threshold'),
+    ('gtf_file', 'GTF file'),
+    ('n_components', 'Number of components'),
+    ('', ''),
+])
+def test_get_param_readable_name_auto(param_name, expected):
+    assert get_param_readable_name(param_name) == expected
+
+
+def test_get_param_readable_name_override():
+    @param_readable_names({'trim_n': 'Trim ambiguous (N) bases'})
+    def func(trim_n=True, other_param=1):
+        pass
+
+    # overridden parameter uses the declared label
+    assert get_param_readable_name('trim_n', func) == 'Trim ambiguous (N) bases'
+    # non-overridden parameters fall back to auto-humanization
+    assert get_param_readable_name('other_param', func) == 'Other param'
+
+
+def test_get_param_readable_name_func_without_overrides():
+    def func(trim_n=True):
+        pass
+
+    # a function without a readable_param_names attribute auto-humanizes
+    assert get_param_readable_name('trim_n', func) == 'Trim n'
+    assert get_param_readable_name('trim_n', None) == 'Trim n'
+
+
+def test_get_param_readable_name_override_beats_special_name():
+    @param_readable_names({'n_components': 'Num comps'})
+    def func(n_components=2):
+        pass
+
+    assert get_param_readable_name('n_components', func) == 'Num comps'
+
+
 @pytest.mark.parametrize(
     "X, labels, expected_bic",
     [


### PR DESCRIPTION
## Summary

The RNAlysis GUI is generated from the API by reflection, and parameter labels in every
auto-built function form were shown verbatim as raw Python `snake_case` identifiers
(e.g. `fastq_folder`, `three_prime_adapters`, `minimum_read_length`, `trim_n`,
`power_transform`). This is the most visible break of the "code-free" promise for
non-programmer biologists.

This PR humanizes those labels using a hybrid approach (auto-humanize + optional override),
strictly **display-only** -- no parameter key, kwarg, import/export, or Pipeline
serialization is affected.

## What changed

- **`utils/generic.py`**
  - `get_param_readable_name(param_name, func=None)`: resolves a per-function override
    first, then a global whole-name special case (`n_components` -> "Number of components"),
    then auto-humanizes `snake_case` (sentence-case + spaces) while preserving a domain
    acronym keep-map (`GO`, `KEGG`, `PCA`, `FDR`, `ID`/`IDs`, `RNA`, `mRNA`, `DESeq2`,
    `SAM`, `BAM`, `FASTQ`, `padj`, `GTF`, `UMAP`, ...).
  - `@param_readable_names({...})` decorator: sets `func.readable_param_names`, mirroring
    how `readable_name` sets `func.readable_name`.
- **`fastq.py`**: applied `@param_readable_names({'trim_n': 'Trim ambiguous (N) bases'})`
  to `trim_adapters_single_end` and `trim_adapters_paired_end` (the clearest auto-humanize
  failure).
- **`gui/gui.py` + `gui/gui_windows.py`**: replaced the raw `QLabel(f'{name}:')` at all 9
  label call-sites with `get_param_readable_name(name, func)`, passing the owning function
  where available so overrides resolve.

## Display-only guarantee

Widget dictionaries are still keyed by the raw `name`
(`self.param_widgets[name]`, etc.), and `get_analysis_kwargs` / `get_function_params` iterate
those raw keys. Only the on-screen `QLabel` text changed. Tooltips/help buttons (from the
`:param:` docstrings) are untouched.

## Tests

- Added pure-Python tests in `tests/test_generic.py` covering the decorator, every acronym
  keep-map case, the whole-name special case, the per-function override path, the
  no-override fallback, and override-beats-special-case precedence.
- Verified (test + inspection) that parameter keys are unchanged and that decorator stacking
  preserves the existing `func_type` / `readable_name` attributes.

Closes #204
