### PR TITLE
Fix always-skipped PantherDB tests: probe supportedgenomes, not /ortholog/

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -68,11 +68,18 @@ def are_dir_trees_equal(dir1, dir2, compare_contents: bool = True, ignore: list 
 
 
 def is_pantherdb_available():
+    # Probe the param-free `supportedgenomes` endpoint that `io.get_legal_panther_taxons` already
+    # POSTs -- it returns HTTP 200 JSON when PantherDB is healthy. The old probe GET-ed the bare
+    # `.../ortholog/` parent, which 404s even on a perfectly healthy service (the real ortholog call
+    # POSTs `.../ortholog/matchortho` with query params), so this probe returned False on every run
+    # and the whole TestPantherOrthologMapper suite was permanently skipped. Catch RequestException
+    # (not just TimeoutError/HTTPError) so an unreachable service can't crash collection at import.
+    url = 'https://www.pantherdb.org/services/oai/pantherdb/supportedgenomes'
     try:
-        req = requests.get('http://www.pantherdb.org/services/oai/pantherdb/ortholog/')
-    except (TimeoutError, requests.exceptions.HTTPError):
+        req = requests.post(url, timeout=(10, 30))
+    except requests.exceptions.RequestException:
         return False
-    if str(req.status_code)[0] in ['4','5']:
+    if str(req.status_code)[0] in ['4', '5']:
         return False
     return True
 

--- a/tests/test_availability_probes.py
+++ b/tests/test_availability_probes.py
@@ -1,0 +1,72 @@
+"""Unit tests for the live-service availability probes in ``tests/__init__.py``.
+
+These probes gate the ``@pytest.mark.skipif(not <SERVICE>_AVAILABLE, ...)`` network tests. A probe
+that reports a *healthy* service as unavailable silently skips real coverage on every CI run, so the
+probes themselves are worth pinning down. All tests here mock the HTTP layer -- no real network -- so
+they belong to the ``unit`` tier (the module name keeps them out of ``integration_net``).
+"""
+import pytest
+import requests
+
+import tests as tests_pkg
+
+
+class _FakeResp:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+@pytest.mark.unit
+class TestIsPantherdbAvailable:
+    """`is_pantherdb_available` must report a healthy PantherDB as up.
+
+    Regression guard for the probe that GET-requested the bare ``.../ortholog/`` parent endpoint,
+    which returns HTTP 404 even when PantherDB is perfectly healthy -- so the probe returned False
+    on *every* run and the whole ``TestPantherOrthologMapper`` suite was permanently skipped.
+    """
+
+    @staticmethod
+    def _healthy_pantherdb(url, *args, **kwargs):
+        # Mirror the real service: the param-free supportedgenomes endpoint answers 200 with JSON,
+        # while the bare .../ortholog/ parent (no query params) 404s even when the service is up.
+        if 'supportedgenomes' in url:
+            return _FakeResp(200)
+        return _FakeResp(404)
+
+    def test_reports_up_when_service_healthy(self, monkeypatch):
+        monkeypatch.setattr(tests_pkg.requests, 'get', self._healthy_pantherdb)
+        monkeypatch.setattr(tests_pkg.requests, 'post', self._healthy_pantherdb)
+        assert tests_pkg.is_pantherdb_available() is True
+
+    def test_probes_supportedgenomes_endpoint(self, monkeypatch):
+        calls = []
+
+        def record(url, *args, **kwargs):
+            calls.append(('post', url, kwargs.get('timeout')))
+            return _FakeResp(200)
+
+        def forbid_get(url, *args, **kwargs):
+            raise AssertionError(f'probe must not GET the 404-ing ortholog parent (got {url})')
+
+        monkeypatch.setattr(tests_pkg.requests, 'post', record)
+        monkeypatch.setattr(tests_pkg.requests, 'get', forbid_get)
+
+        assert tests_pkg.is_pantherdb_available() is True
+        assert len(calls) == 1
+        _, url, timeout = calls[0]
+        assert 'supportedgenomes' in url
+        assert timeout is not None, 'probe must set a request timeout so a hung service cannot block collection'
+
+    def test_reports_down_on_connection_error(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise requests.exceptions.ConnectionError('service unreachable')
+
+        monkeypatch.setattr(tests_pkg.requests, 'post', boom)
+        monkeypatch.setattr(tests_pkg.requests, 'get', boom)
+        assert tests_pkg.is_pantherdb_available() is False
+
+    @pytest.mark.parametrize('status_code', [404, 500])
+    def test_reports_down_on_4xx_5xx(self, monkeypatch, status_code):
+        monkeypatch.setattr(tests_pkg.requests, 'post', lambda *a, **k: _FakeResp(status_code))
+        monkeypatch.setattr(tests_pkg.requests, 'get', lambda *a, **k: _FakeResp(status_code))
+        assert tests_pkg.is_pantherdb_available() is False


### PR DESCRIPTION
Closes #229.

## Problem

`is_pantherdb_available()` probed `GET http://www.pantherdb.org/services/oai/pantherdb/ortholog/` — a bare parent path that returns **HTTP 404 even when PantherDB is healthy** (the real call is `POST .../ortholog/matchortho` with query params). The probe treats any 4xx/5xx as "down", so it returned `False` on **every** run and `TestPantherOrthologMapper` was skipped in all CI runs, never once executing.

Two problems in one small function:
1. **Wrong endpoint/method** → permanent false-negative → 6 integration tests silently skipped forever.
2. **Fragile error handling** → only `(TimeoutError, HTTPError)` caught and no timeout set, so a real `ConnectionError` (service unreachable) would propagate out of the module-level `PANTHERDB_AVAILABLE = is_pantherdb_available()` and crash test **collection** at import.

## Fix

Probe the param-free `supportedgenomes` endpoint that `io.get_legal_panther_taxons` already POSTs (returns 200 JSON when healthy), catch `requests.exceptions.RequestException`, and set an explicit `(10, 30)` timeout — mirroring the existing `is_orthoinspector_available` pattern.

## Tests (TDD)

New `tests/test_availability_probes.py` (`unit` tier, runs on all CI cells — mocks the HTTP layer, no real network) pins the probe's contract:
- reports **up** when the service is healthy (simulating the real service, where `/ortholog/` 404s but `supportedgenomes` 200s — this is the exact case the old probe got wrong);
- POSTs the `supportedgenomes` endpoint **with a timeout** (and must not GET the 404-ing parent);
- reports **down** on `ConnectionError` and on 4xx/5xx responses.

Written failing first (3 of 5 red against the old probe), then made green.

### Verification

- New unit tests: **5 passed**.
- Previously-always-skipped live suite `tests/test_io.py::TestPantherOrthologMapper`: **6 passed** against the live PantherDB service (~27s) — coverage that had never run before.

Could not run the full CI matrix locally (no R / kallisto / bowtie2 here); this change touches only the network-availability probe, so those tiers are unaffected.

## Scope / risk

Test-infrastructure only. No product code, no public API, no serialized format, no numerical output, and no GUI-visible change — so no `HISTORY.rst` entry and no screenshots required.
