### PR TITLE
fix: guard Box-Cox transform against overflow (PCA/clustering NaN crash)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1 (unreleased)
+-------------------
+
+Fixed
+******
+* Fixed a crash (``ValueError: Input X contains NaN``) in the PCA functions (``pca``, ``sort_by_principal_component``, ``split_by_principal_components``) and in the power-transform clustering methods when the data contained a near-constant, high-magnitude feature measured across very few samples. The per-feature Box-Cox power transform could overflow to non-finite values on such a feature; RNAlysis now detects this and standardizes the affected feature *without* the power transform (emitting a warning) instead of crashing. Results for all other data are unchanged.
+
 4.3.0 (2026-08-10)
 -------------------
 

--- a/rnalysis/utils/generic.py
+++ b/rnalysis/utils/generic.py
@@ -244,6 +244,17 @@ def standard_box_cox(data: Union[np.ndarray, pl.DataFrame],
         box_cox_array = _parallel_box_cox(array, backend=parallel_backend, n_jobs=joblib.cpu_count())
     else:
         box_cox_array = _box_cox_fit_transform(array)
+    # A near-constant, high-magnitude column with very few samples can drive the per-column Box-Cox
+    # MLE lambda so high that the transform overflows float64, yielding non-finite values that later
+    # crash PCA/clustering ("Input X contains NaN"). Fall back to the raw values for any such column
+    # (i.e. standardize it without the power transform, as power_transform=False would) so a single
+    # unstable column no longer poisons the whole transform. Well-behaved columns are untouched.
+    unstable_columns = ~np.isfinite(box_cox_array).all(axis=0)
+    if unstable_columns.any():
+        box_cox_array[:, unstable_columns] = array[:, unstable_columns]
+        warnings.warn(f"The power transform produced non-finite values for {int(unstable_columns.sum())} "
+                      f"column(s) (e.g. a near-constant column with extreme values); these columns were "
+                      f"standardized without the power transform instead.")
     res_array = StandardScaler().fit_transform(box_cox_array)
     if isinstance(data, pl.DataFrame):
         return data.select(~cs.numeric()).with_columns(

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -84,6 +84,27 @@ def test_standard_box_cox_default_is_sequential(monkeypatch):
     assert np.array_equal(standard_box_cox(array), reference)
 
 
+@pytest.mark.parametrize('parallel_backend', ['sequential', 'threading'])
+def test_standard_box_cox_survives_boxcox_overflow(parallel_backend, monkeypatch):
+    # A near-constant, high-magnitude column with very few samples drives the per-column Box-Cox MLE
+    # lambda to an extreme value whose transform overflows float64 -> non-finite output. That used to
+    # crash PCA/clustering downstream (sklearn: "Input X contains NaN"). Such a column must be handled
+    # gracefully (standardized without the power transform), while well-behaved columns stay untouched.
+    monkeypatch.setattr(generic, 'BOX_COX_PARALLEL_MIN_COLUMNS', 2)
+    overflow_col = np.array([8482.73, 8459.93, 8423.67, 8288.78])  # the real GFP-like offender
+    good = np.array([[10.0, 3.0], [50.0, 90.0], [200.0, 40.0], [1000.0, 7.0]])
+    array = np.column_stack([good[:, 0], overflow_col, good[:, 1]])
+
+    res = standard_box_cox(array, parallel_backend=parallel_backend)
+    assert res.shape == array.shape
+    assert np.isfinite(res).all(), 'the power transform must not leak NaN/inf that crash PCA'
+
+    # the well-behaved columns must be identical to their own Box-Cox+standardize result -- the
+    # overflow fallback only touches the offending column.
+    good_ref = StandardScaler().fit_transform(PowerTransformer(method='box-cox').fit_transform(good + 1))
+    assert np.allclose(res[:, [0, 2]], good_ref, rtol=0, atol=1e-10)
+
+
 def test_color_generator():
     gen = color_generator()
     preset_colors = ['tab:blue', 'tab:red', 'tab:green', 'tab:orange', 'tab:purple', 'tab:brown', 'tab:pink',


### PR DESCRIPTION
Fixes the PCA crash reported while testing 4.3.0.

## Symptom
`CountFilter.pca()` raised `ValueError: Input X contains NaN` on a table with **no null values**, preceded by `overflow encountered in square` and a Box-Cox "constrained optimum" warning.

## Root cause
The table had only **4 numeric columns** (grouped/averaged samples) × ~4,200 genes. PCA transposes to samples × genes, so the per-column Box-Cox power transform runs on each gene across just **4 values**. A near-constant, high-magnitude gene (a GFP-like reporter at ~8,400 across the 4 samples) drives the Box-Cox MLE lambda to ~85; the transform overflows float64 → non-finite → sklearn PCA rejects it.

**Not a 4.3.0 regression:** V4.2.0's `standard_box_cox` is the identical `StandardScaler().fit_transform(PowerTransformer('box-cox').fit_transform(array + 1))` and crashes on the same data. The 4.3.0 Box-Cox parallelization is not involved (the sequential path yields the same single bad column). This is a pre-existing fragility.

## Fix
In `standard_box_cox`, detect any column whose Box-Cox output is non-finite and fall back to the raw values for that column (i.e. standardize it *without* the power transform, exactly as `power_transform=False` would), emitting a warning. Well-behaved columns are byte-for-byte unchanged.

## Tests
- New `test_standard_box_cox_survives_boxcox_overflow` (sequential + threading) using the real offending column: asserts the output is all-finite and that well-behaved columns match their own Box-Cox+standardize result.
- Existing `test_standard_box_cox_default_is_sequential` (bit-identical to the old pipeline) and the committed-truth `test_split_by_principal_components` still pass → no change to normal results.
- Verified end-to-end on the reporter's actual CSV: `standard_box_cox` output is all-finite and `PCA().fit_transform` succeeds.

## Release note
Placed the changelog entry under a new **`4.3.1 (unreleased)`** section, since 4.3.0 is already tagged/released. If you'd rather fold this into a re-tagged 4.3.0, I'll move the entry up.

Behind-the-scenes numeric fix — no GUI dialog change, so no screenshot needed.
