### PR TITLE
Fix packaged-app splash screen: stuck-open bug, DPI blur, and PyInstaller cleanup

### DIFF
--- a/RNAlysis.spec
+++ b/RNAlysis.spec
@@ -28,13 +28,60 @@ hiddenimports += ['matplotlib.backends.backend_pdf', 'matplotlib.backends.backen
                   'matplotlib.backends.backend_agg', 'matplotlib.backends.backend_pgf',
                   'matplotlib.backends.backend_ps']
 
+# UPX-compressing Qt's core libraries (and the CPython DLL) is a known source of slow
+# startup (extra decompression on load), occasional crashes, and AV false positives.
+# Patterns are matched against binary filenames via pathlib.PurePath.match() (supports '*').
+UPX_EXCLUDE = [
+    'Qt6*.dll', 'libQt6*.dylib', 'libQt6*.so*',
+    'python3*.dll',
+]
+
+# PyInstaller's default bootloader manifest (see PyInstaller.utils.win32.winmanifest) declares
+# no DPI awareness, so on a scaled display (125%/150%/...) Windows bitmap-stretches the whole
+# bootloader process -- including the Splash() screen, which is rendered by the bootloader
+# itself before Qt (and Qt's own DPI-awareness call) ever starts. That stretching is exactly
+# what makes the splash look oversized and blurry compared to the in-app QSplashScreen, which
+# Qt renders after declaring proper DPI awareness at runtime. Embedding this manifest (based on
+# PyInstaller's own default, with dpiAware/dpiAwareness added) fixes it at the source instead of
+# guessing a shrink factor for splash.png. Windows-only; PyInstaller ignores/warns on other OSes.
+WINDOWS_MANIFEST = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"></supportedOS>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"></supportedOS>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"></supportedOS>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"></supportedOS>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
+    </dependentAssembly>
+  </dependency>
+</assembly>
+"""
+
 with open(Path(get_hook_dirs()[0]).joinpath('hook-pygraphviz.py')) as infile:
     hook_path = Path('hooks')
-    hook_path.mkdir()
+    hook_path.mkdir(exist_ok=True)
     with open(hook_path.joinpath('hook-graphviz.py'), 'w') as outfile:
         outfile.write(infile.read())
-
-block_cipher = None
 
 a = Analysis(
     ['rnalysis_app.py'],
@@ -45,12 +92,9 @@ a = Analysis(
     hookspath=[hook_path],
     runtime_hooks=[],
     excludes=[],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
     noarchive=False,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data)
 
 if is_darwin:
     exe_contents = (pyz, a.scripts, a.binaries, a.zipfiles, a.datas, [],)
@@ -65,7 +109,7 @@ else:
                     text_color='black',
                     always_on_top=False)
     exe_contents = (pyz, splash, a.scripts, [],)
-    exe_kwargs = dict(exclude_binaries=True, icon='rnalysis/favicon.ico')
+    exe_kwargs = dict(exclude_binaries=True, icon='rnalysis/favicon.ico', manifest=WINDOWS_MANIFEST)
 
 exe = EXE(
     *exe_contents,
@@ -75,13 +119,17 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
+    upx_exclude=UPX_EXCLUDE,
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    hide_console='hide-late'
+    hide_console='hide-late',
+    # Default '_internal' is a generic name that's easy to mistake for another app's support
+    # folder if multiple onedir PyInstaller apps are unpacked side by side; scope it to us.
+    contents_directory='RNAlysis_internal',
 )
 
 if not is_darwin:
@@ -93,6 +141,6 @@ if not is_darwin:
         a.datas,
         strip=False,
         upx=True,
-        upx_exclude=[],
+        upx_exclude=UPX_EXCLUDE,
         name='RNAlysis-4.3.0',
     )

--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -4773,9 +4773,13 @@ def customwarn(message, category, filename, lineno, file=None, line=None):  # pr
 async def run():  # pragma: no cover
     warnings.showwarning = customwarn
     # close built-in splash screen in frozen app version of RNAlysis
-    if '_PYIBoot_SPLASH' in os.environ and importlib.util.find_spec("pyi_splash"):
-        import pyi_splash
-        pyi_splash.close()
+    if '_PYIBoot_SPLASH' in os.environ:
+        try:
+            import pyi_splash
+        except ImportError:
+            pass
+        else:
+            pyi_splash.close()
     lockfile = QtCore.QLockFile(QtCore.QDir.tempPath() + '/RNAlysis.lock')
     if lockfile.tryLock(100):
         show_app = True


### PR DESCRIPTION
## Summary
- The bootloader splash could get stuck open forever: closing it depended on `importlib.util` being implicitly available (normally provided by `site.py`, which PyInstaller's frozen bootloader disables), so `importlib.util.find_spec(...)` could raise before `pyi_splash.close()` ever ran — with no visible console (`hide-late`) to reveal why. Replaced with a plain `try`/`import`/`except`.
- The same splash rendered oversized and blurry vs. the in-app `QSplashScreen`: PyInstaller's default bootloader manifest declares no DPI awareness, so Windows bitmap-stretches the whole bootloader process (incl. the pre-Qt splash) on any scaled display. Embedded a custom manifest declaring `PerMonitorV2` DPI awareness to fix this at the source.
- Spec cleanup: dropped `cipher`/`win_no_prefer_redirects`/`win_private_assemblies` (no-ops on PyInstaller 6.x), made the `hooks/` dir creation idempotent (`exist_ok=True`), excluded Qt/CPython binaries from UPX compression (known source of slow startup, crashes, and AV false positives), and renamed the onedir contents folder from the generic `_internal` to `RNAlysis_internal`.

## Test plan
- [ ] Build with `pyinstaller RNAlysis.spec` on Windows and confirm the splash closes promptly and matches the in-app splash's proportions/sharpness, ideally on a display with >100% scaling
- [ ] Build on macOS and confirm it still launches normally (manifest/UPX-exclude changes are Windows-only, no-op elsewhere)
- [ ] Spot-check that Qt DLLs are present uncompressed (or at least not UPX-mangled) in the onedir output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SwLapVci6iu11FVD2g3VM