### PR TITLE
Retry transient JDK download failures in install_jdk

### DIFF
--- a/rnalysis/utils/installs.py
+++ b/rnalysis/utils/installs.py
@@ -8,6 +8,8 @@ from shutil import copyfileobj
 from typing import Literal, Union
 from urllib.request import urlopen
 
+import tenacity
+
 from rnalysis.utils import io
 
 try:
@@ -17,8 +19,11 @@ except ImportError:  # pragma: no cover
 
 
     class jdk:  # pragma: no cover
+        class JdkError(Exception):
+            pass
+
         @staticmethod
-        def install(version):
+        def install(version, *args, **kwargs):
             warnings.warn("Cannot install JDK.")
 
 PICARD_JAR = Path(os.environ.get('PICARDTOOLS_JAR', io.get_data_dir().joinpath('picard.jar')))
@@ -69,13 +74,23 @@ def is_jdk_installed():
     return False
 
 
+@tenacity.retry(retry=tenacity.retry_if_exception_type(jdk.JdkError),
+                stop=tenacity.stop_after_attempt(3),
+                wait=tenacity.wait_random_exponential(multiplier=1, max=30),
+                reraise=True)
+def _download_and_install_jdk():
+    # the JDK is fetched from an external server (Adoptium -> GitHub release asset) that intermittently
+    # drops connections; retry a few times before giving up so transient network blips don't fail the install.
+    jdk.install(str(JDK_VERSION), path=JDK_ROOT.as_posix())
+
+
 def install_jdk():
     if not is_jdk_installed():
         print("Installing Java...")
         if JDK_ROOT.exists():
             shutil.rmtree(JDK_ROOT)
         JDK_ROOT.mkdir(parents=True, exist_ok=True)
-        jdk.install(str(JDK_VERSION), path=JDK_ROOT.as_posix())
+        _download_and_install_jdk()
         print('Done')
 
 

--- a/tests/test_installs.py
+++ b/tests/test_installs.py
@@ -76,6 +76,38 @@ def test_install_jdk_already_installed(monkeypatch):
     mock_install.assert_not_called()
 
 
+def test_install_jdk_retries_transient_download_error(monkeypatch):
+    monkeypatch.setattr(installs, 'is_jdk_installed', lambda: False)
+    monkeypatch.setattr('pathlib.Path.exists', lambda self: False)
+    monkeypatch.setattr('time.sleep', lambda *args, **kwargs: None)  # don't actually wait between retries
+    attempts = {'n': 0}
+
+    def flaky_install(*args, **kwargs):
+        attempts['n'] += 1
+        if attempts['n'] < 3:
+            raise installs.jdk.JdkError('Remote end closed connection without response')
+
+    monkeypatch.setattr('jdk.install', flaky_install)
+    install_jdk()
+    assert attempts['n'] == 3  # failed twice, succeeded on the third try
+
+
+def test_install_jdk_reraises_after_exhausting_retries(monkeypatch):
+    monkeypatch.setattr(installs, 'is_jdk_installed', lambda: False)
+    monkeypatch.setattr('pathlib.Path.exists', lambda self: False)
+    monkeypatch.setattr('time.sleep', lambda *args, **kwargs: None)
+    attempts = {'n': 0}
+
+    def always_fail(*args, **kwargs):
+        attempts['n'] += 1
+        raise installs.jdk.JdkError('Remote end closed connection without response')
+
+    monkeypatch.setattr('jdk.install', always_fail)
+    with pytest.raises(installs.jdk.JdkError):
+        install_jdk()
+    assert attempts['n'] == 3  # gives up after 3 attempts
+
+
 # Test is_picard_installed
 def test_is_picard_installed_success(monkeypatch, mock_jdk_install):
     monkeypatch.setattr(io, 'run_subprocess', lambda *args, **kwargs: (None, ['Version']))


### PR DESCRIPTION
## Summary
Diagnosed from the failing **Integration tests (R / CLI tools)** job on PR #239 ([run](https://github.com/GuyTeichman/RNAlysis/actions/runs/31647812408/job/94285329812?pr=239)), where `test_generate_picard_basecall[FastqToSam]` and `[MarkDuplicates]` failed with:

```
http.client.RemoteDisconnected: Remote end closed connection without response
→ jdk.JdkError: Remote end closed connection without response
```

The failure was **unrelated to PR #239** (that PR only touches PyInstaller packaging). Root cause: `install_jdk()` downloads the PicardTools JDK from an external server (Adoptium, which 302-redirects to a GitHub release asset) and the remote dropped the connection mid-download. There was **no retry**, so a single transient network blip failed the whole install — flaky in CI, and a real failure mode for users installing PicardTools.

## Changes
- Wrap the `jdk.install(...)` download in a bounded `tenacity` retry (3 attempts, jittered exponential backoff, `reraise=True`) that retries **only** `jdk.JdkError` and re-raises the original error if all attempts are exhausted. Matches the external-service retry convention already used in `io.py`.
- Give the `install-jdk`-missing fallback stub a `JdkError` attribute (and let its `install` stub accept the `path=` kwarg) so the decorator can reference `jdk.JdkError` at import time even when `install-jdk` isn't installed.

## Test plan
- [x] `pytest tests/test_installs.py` — 18 passed (random order), including two new tests: retry-then-succeed on a transient `JdkError`, and re-raise after exhausting retries (both patch `time.sleep` so they run fast).
- [ ] Could not exercise the real network download path locally (integration test needs the live Adoptium endpoint); the retry logic is covered by the unit tests above.

## Notes
- No `HISTORY.rst` entry added: `development` has no unreleased section yet and the related in-flight PR #239 didn't add one either — flagging here so a **Fixed** bullet ("retry transient JDK/PicardTools download failures") can be slotted in at release time.
- Not a visible GUI change (internal util, private helper), so no dialog screenshot (rule 9 exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)