### PR TITLE
Add beta freeze-smoke-test lane (issue #283)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -68,29 +68,37 @@ before. If a beta leaves a dated HISTORY, a bumped version, a new commit, or a t
 normal test suite can't catch (missing bundled data files, hidden imports, Qt plugins, one-file vs
 one-dir issues) — and to manually exercise the frozen app, *without* cutting a release.
 
-**Mechanism:** `.github/workflows/pyinstaller.yml`'s `workflow_dispatch` trigger has a `beta`
-boolean input (**default `true`**). When `beta=true` it **skips the `createrelease` job entirely**
-— no commit to `master`, no GitHub Release — and runs only the cross-platform `build` job,
-uploading the frozen apps as **run artifacts** you download from the Actions run page. It is the
-*exact same* `build` job a real release uses (same PyInstaller spec, same dependency install), so a
-green beta is a faithful prediction of the release freeze — the whole reason it's wired into the
-same workflow rather than a separate, driftable copy.
+**Mechanism:** `.github/workflows/pyinstaller.yml` treats **any manual run (`workflow_dispatch`)
+as a beta** — the event type is the sole discriminator, so there is no input to set (or get wrong).
+A manual run **skips the `createrelease` job entirely** — no commit to `master`, no GitHub Release —
+and runs only the cross-platform `build` job, uploading the frozen apps as **run artifacts** you
+download from the Actions run page. Only a tag push (`V*`) cuts a real release. It is the *exact
+same* `build` job a real release uses (same PyInstaller spec, same dependency install), so a green
+beta is a faithful prediction of the release freeze — the whole reason it's wired into the same
+workflow rather than a separate, driftable copy. Because the beta path keys off the event type and
+adds no `workflow_dispatch` input, you can dispatch a beta from `development` (or any feature branch)
+**without the change first having to land on the default branch** — the ref you dispatch is the file
+that runs.
 
 ```bash
 # Dispatch a beta build of whatever is on `development` (or any branch/ref you want to
-# freeze-test). `beta` defaults to true, so this alone is enough:
+# freeze-test). A manual run is always a beta — there are no inputs to pass:
 gh workflow run pyinstaller.yml --ref development
 
-# ...or be explicit:
-gh workflow run pyinstaller.yml --ref development -f beta=true
-
-# Watch it:
-gh run watch --exit-status $(gh run list --workflow pyinstaller.yml --limit 1 --json databaseId -q '.[0].databaseId')
+# Grab THIS run's id. Filter to the branch + the manual (workflow_dispatch) event so you don't
+# watch an older or concurrent run, and give the freshly dispatched run a moment to register:
+sleep 5
+run_id=$(gh run list --workflow pyinstaller.yml --branch development --event workflow_dispatch \
+    --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch --exit-status "$run_id"
 ```
 
-When it finishes, open the run's **Artifacts** section, download `RNAlysis-BETA-macos-M1-<sha>` /
-`RNAlysis-BETA-windows-<sha>`, unzip, and launch. The build is unsigned, so on macOS clear the
-quarantine bit first: `xattr -dr com.apple.quarantine RNAlysis.app` (same as any unsigned local
+When it finishes, open the run's **Artifacts** section and download `RNAlysis-BETA-macos-M1-<sha>` /
+`RNAlysis-BETA-windows-<sha>`. Note the **double zip**: GitHub wraps every artifact in its own zip,
+and *inside* that sits the build's own `RNAlysis-<version>_<os>.zip` — so you unzip **twice** before
+`RNAlysis.app` (macOS) / the `RNAlysis-<version>/` folder (Windows) appears. Then launch it. The
+build is unsigned, so on macOS clear the quarantine bit first — *after* the second unzip, once
+`RNAlysis.app` exists: `xattr -dr com.apple.quarantine RNAlysis.app` (same as any unsigned local
 build).
 
 **What a beta deliberately does NOT do — its isolation contract:**

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,9 +13,16 @@ description: >-
   cleanly undone) — codifying the exact order is what prevents a missed step, such as a version
   string left stale in one of five files, stale/orphaned docs pages shipped as the release's
   in-app help, a tag pushed before `HISTORY.rst` has a real date, or a PyPI upload from the
-  wrong commit. Not for routine feature/fix PRs, which follow the normal branch-off-`development`
-  flow in `.claude/workflows.md` — this skill covers only the release act itself, and several of
-  its steps require the maintainer's own admin credentials, not just any contributor's.
+  wrong commit. Also covers a separate **beta lane** — a private freeze smoke-test that builds the
+  standalone app through CI (no GitHub Release, no version bump, no commits, no HISTORY date) to
+  verify the PyInstaller freeze still works and hand you an executable to test by hand. Use for the
+  stable procedure when Guy — the maintainer — says "cut a release", "release a new version",
+  "ship 4.x.0", "bump the version", or asks to merge `development` into `master`; use for the beta
+  lane when he says "run a beta", "beta build", "freeze smoke-test", or "test the
+  PyInstaller/standalone build". Not for routine feature/fix PRs, which follow the normal
+  branch-off-`development` flow in `.claude/workflows.md` — this skill covers only the release act
+  itself, and several of its steps require the maintainer's own admin credentials, not just any
+  contributor's.
 ---
 
 # Cutting an RNAlysis release
@@ -27,6 +34,92 @@ with Guy before the irreversible steps (pushing the tag, `twine upload`) if ther
 
 Read `.claude/workflows.md`'s "Release (maintainer)" and "Branching & releases" sections first —
 this skill is the expanded version of those.
+
+---
+
+## Two lanes: pick the right one
+
+This skill documents **two distinct procedures**. Don't confuse them:
+
+- **Stable lane** — Preconditions → Steps 1–7 below. The real thing: `development` reaches
+  `master`, the version is bumped, the vocabulary snapshot and docs are regenerated, a tag is
+  pushed, standalone builds are published as a GitHub Release, and the PyPI package is uploaded.
+  Has **irreversible** steps. This is what "cut a release" means.
+- **Beta lane** — the [Beta lane](#beta-lane--freeze-smoke-test-no-release) section directly below.
+  A throwaway **freeze smoke-test**: its only job is to prove `pyinstaller RNAlysis.spec` still
+  produces a launchable macOS + Windows app and to hand you those executables to click through by
+  hand. It **publishes nothing and commits nothing.**
+
+**The one rule that binds the two lanes together — and the reason this section exists at all:**
+the `HISTORY.rst` date is stamped **only** in the stable lane (Preconditions #2). A beta must
+**never** turn `X.Y.Z (unreleased)` into a dated header, bump the version, or push to
+`master`/`development`. The 4.3.0 cycle is the cautionary tale: a beta was tested informally, the
+HISTORY header acquired a date while the version was in fact unreleased, and "is 4.3.0 out?" became
+ambiguous — to the maintainer, and to any other agent reading the repo. The whole point of the beta
+lane is that someone reading the repo mid-beta sees the **exact same** "still unreleased" state as
+before. If a beta leaves a dated HISTORY, a bumped version, a new commit, or a tag behind, it has
+**failed its contract**, not succeeded.
+
+---
+
+## Beta lane — freeze smoke-test (no release)
+
+**When to use it:** you want to confirm the PyInstaller freeze still works — it breaks in ways the
+normal test suite can't catch (missing bundled data files, hidden imports, Qt plugins, one-file vs
+one-dir issues) — and to manually exercise the frozen app, *without* cutting a release.
+
+**Mechanism:** `.github/workflows/pyinstaller.yml`'s `workflow_dispatch` trigger has a `beta`
+boolean input (**default `true`**). When `beta=true` it **skips the `createrelease` job entirely**
+— no commit to `master`, no GitHub Release — and runs only the cross-platform `build` job,
+uploading the frozen apps as **run artifacts** you download from the Actions run page. It is the
+*exact same* `build` job a real release uses (same PyInstaller spec, same dependency install), so a
+green beta is a faithful prediction of the release freeze — the whole reason it's wired into the
+same workflow rather than a separate, driftable copy.
+
+```bash
+# Dispatch a beta build of whatever is on `development` (or any branch/ref you want to
+# freeze-test). `beta` defaults to true, so this alone is enough:
+gh workflow run pyinstaller.yml --ref development
+
+# ...or be explicit:
+gh workflow run pyinstaller.yml --ref development -f beta=true
+
+# Watch it:
+gh run watch --exit-status $(gh run list --workflow pyinstaller.yml --limit 1 --json databaseId -q '.[0].databaseId')
+```
+
+When it finishes, open the run's **Artifacts** section, download `RNAlysis-BETA-macos-M1-<sha>` /
+`RNAlysis-BETA-windows-<sha>`, unzip, and launch. The build is unsigned, so on macOS clear the
+quarantine bit first: `xattr -dr com.apple.quarantine RNAlysis.app` (same as any unsigned local
+build).
+
+**What a beta deliberately does NOT do — its isolation contract:**
+
+- ❌ **No `bumpversion`, no `.bumpversion.cfg` edit.** The frozen app self-reports whatever version
+  is currently committed (e.g. `4.3.0`); the beta identity lives only in the downloaded artifact's
+  name, not inside the app. (Making the *app itself* read `X.Y.Zb1` was considered and dropped —
+  see issue #283 — because it requires a committed bump, which is exactly the residue this contract
+  forbids.)
+- ❌ **No `HISTORY.rst` date stamp.** `X.Y.Z (unreleased)` stays `(unreleased)`. The date is a
+  stable-lane act only.
+- ❌ **No commit to `master` or `development`, and no new tag.** Nothing is pushed anywhere.
+- ❌ **No API-vocabulary regen (Step 3), no docs regen (Step 4).** Those are versioned release
+  artifacts; a beta freezes the branch exactly as it stands.
+- ❌ **No PyPI upload, no GitHub Release** (not even a pre-release).
+
+**Verify the guardrail held** (worth doing once, after your first beta, to trust the wiring):
+
+```bash
+git fetch origin
+git log origin/master -1        # unchanged — no auto-commit landed on master
+gh release list --limit 3       # no new release/pre-release created for this build
+```
+
+**Cleanup:** none. Run artifacts expire on their own (14-day retention, set on the upload step);
+there is no branch, tag, commit, or release to delete. That "nothing to clean up" property *is* the
+design goal.
+
+---
 
 ## A load-bearing fact: four narrow, deliberate exceptions to "never commit to master/development"
 

--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -5,6 +5,11 @@ on:
         tags:
             - 'V*' #
     workflow_dispatch:
+        inputs:
+            beta:
+                description: 'Beta freeze smoke-test: build the standalone app only — no GitHub Release, no commits, no version bump. Produces downloadable run artifacts to test the PyInstaller freeze by hand.'
+                type: boolean
+                default: true
 
 env:
     HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
@@ -13,6 +18,10 @@ jobs:
 
     createrelease:
         name: Create Release
+        # Skipped for a beta freeze smoke-test (workflow_dispatch with beta=true): a beta must never
+        # commit to master or publish a Release. Tag pushes, and an explicit beta=false dispatch,
+        # still run the full release path below.
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.beta == false }}
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -62,7 +71,14 @@ jobs:
     build:
         name: Build packages
         needs: createrelease
+        # Runs for both real releases and beta smoke-tests. always() lets it proceed when
+        # createrelease was skipped (a beta); it is still blocked if createrelease actually failed.
+        if: ${{ always() && needs.createrelease.result != 'failure' && needs.createrelease.result != 'cancelled' }}
         runs-on: ${{ matrix.os }}
+        # IS_BETA is the string 'true' only for a beta freeze-test dispatch; it flips the publish
+        # tail (upload to a Release) off and the run-artifact upload on, without touching the build.
+        env:
+            IS_BETA: ${{ github.event_name == 'workflow_dispatch' && inputs.beta }}
         strategy:
             matrix:
                 include:
@@ -136,19 +152,30 @@ jobs:
             - name: Build with pyinstaller for ${{ matrix.TARGET }}
               run: ${{ matrix.CMD_BUILD }}
 
+            - name: Upload beta artifact (freeze smoke-test)
+              if: ${{ env.IS_BETA == 'true' }}
+              uses: actions/upload-artifact@v7
+              with:
+                  name: RNAlysis-BETA-${{ matrix.TARGET }}-${{ github.sha }}
+                  path: ./dist/${{ matrix.OUT_FILE_NAME }}
+                  retention-days: 14
+
             - name: Load Release URL File from release job
+              if: ${{ env.IS_BETA != 'true' }}
               uses: actions/download-artifact@v8
               with:
                   name: release_url
                   path: release_url
 
             - name: Get Release File Name & Upload URL
+              if: ${{ env.IS_BETA != 'true' }}
               id: get_release_info
               run: |
                   value=$(cat release_url/release_url.txt)
                   echo "UPLOAD_URL=$value" >> $GITHUB_ENV
               shell: bash
             - name: Upload Release Asset
+              if: ${{ env.IS_BETA != 'true' }}
               id: upload-release-asset
               uses: softprops/action-gh-release@v3
               env:

--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -5,11 +5,12 @@ on:
         tags:
             - 'V*' #
     workflow_dispatch:
-        inputs:
-            beta:
-                description: 'Beta freeze smoke-test: build the standalone app only — no GitHub Release, no commits, no version bump. Produces downloadable run artifacts to test the PyInstaller freeze by hand.'
-                type: boolean
-                default: true
+        # A manual run is ALWAYS a beta freeze smoke-test: it builds the standalone app only
+        # (no GitHub Release, no commit, no version bump) and uploads the frozen apps as
+        # downloadable run artifacts to test the PyInstaller freeze by hand. Only a tag push
+        # (the `V*` trigger above) cuts a real release. The event type is the sole discriminator,
+        # so there is deliberately no `beta` input to get wrong — and nothing here has to reach
+        # the default branch before a beta can be dispatched from a feature/development branch.
 
 env:
     HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
@@ -18,10 +19,10 @@ jobs:
 
     createrelease:
         name: Create Release
-        # Skipped for a beta freeze smoke-test (workflow_dispatch with beta=true): a beta must never
-        # commit to master or publish a Release. Tag pushes, and an explicit beta=false dispatch,
-        # still run the full release path below.
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.beta == false }}
+        # Runs ONLY on a tag push (github.event_name == 'push'). Every manual run
+        # (workflow_dispatch) is a beta freeze smoke-test and must never commit to master or
+        # publish a Release, so createrelease is skipped for it — no exceptions, no input to flip.
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -72,13 +73,10 @@ jobs:
         name: Build packages
         needs: createrelease
         # Runs for both real releases and beta smoke-tests. always() lets it proceed when
-        # createrelease was skipped (a beta); it is still blocked if createrelease actually failed.
+        # createrelease was skipped (a manual beta run); it is still blocked if createrelease
+        # actually failed on a real release (don't upload assets to a Release that never got made).
         if: ${{ always() && needs.createrelease.result != 'failure' && needs.createrelease.result != 'cancelled' }}
         runs-on: ${{ matrix.os }}
-        # IS_BETA is the string 'true' only for a beta freeze-test dispatch; it flips the publish
-        # tail (upload to a Release) off and the run-artifact upload on, without touching the build.
-        env:
-            IS_BETA: ${{ github.event_name == 'workflow_dispatch' && inputs.beta }}
         strategy:
             matrix:
                 include:
@@ -153,7 +151,8 @@ jobs:
               run: ${{ matrix.CMD_BUILD }}
 
             - name: Upload beta artifact (freeze smoke-test)
-              if: ${{ env.IS_BETA == 'true' }}
+              # Manual runs only: the standalone app as a downloadable run artifact, no Release.
+              if: ${{ github.event_name == 'workflow_dispatch' }}
               uses: actions/upload-artifact@v7
               with:
                   name: RNAlysis-BETA-${{ matrix.TARGET }}-${{ github.sha }}
@@ -161,21 +160,21 @@ jobs:
                   retention-days: 14
 
             - name: Load Release URL File from release job
-              if: ${{ env.IS_BETA != 'true' }}
+              if: ${{ github.event_name != 'workflow_dispatch' }}
               uses: actions/download-artifact@v8
               with:
                   name: release_url
                   path: release_url
 
             - name: Get Release File Name & Upload URL
-              if: ${{ env.IS_BETA != 'true' }}
+              if: ${{ github.event_name != 'workflow_dispatch' }}
               id: get_release_info
               run: |
                   value=$(cat release_url/release_url.txt)
                   echo "UPLOAD_URL=$value" >> $GITHUB_ENV
               shell: bash
             - name: Upload Release Asset
-              if: ${{ env.IS_BETA != 'true' }}
+              if: ${{ github.event_name != 'workflow_dispatch' }}
               id: upload-release-asset
               uses: softprops/action-gh-release@v3
               env:


### PR DESCRIPTION
Closes #283.

## What & why

Adds a private **beta lane** to the release process whose only job is to **verify the PyInstaller freeze on macOS + Windows** and hand the maintainer a runnable app to test by hand — *without* touching any shared or serialized release state. This closes the gap that caused the 4.3.0 "dated-but-unreleased HISTORY header" ambiguity: a beta now leaves the repo byte-identical, so anyone (human or agent) reading it mid-beta sees the same "still unreleased" state.

## Design: the event type is the discriminator

A **tag push** (`V*`) cuts a real release; **any manual run** (`workflow_dispatch`) is a beta freeze smoke-test. There is deliberately **no `beta` input** — the event type alone decides, which means:
- there's no `beta=false` mode to misuse (an early draft's `beta=false` would have run `createrelease`, committing to `master` and creating a Release with an invalid `tag_name: refs/heads/<branch>`); and
- a beta needs **nothing on the default branch** to work: GitHub runs the workflow file from the dispatched ref ([docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)), and `master` already carries the bare `workflow_dispatch:` trigger, so `gh workflow run pyinstaller.yml --ref development` runs development's gated file today.

## Changes

**`.github/workflows/pyinstaller.yml`**
- Every gate keys off `github.event_name`. On a manual run the `createrelease` job is **skipped** (no commit to `master`, no GitHub Release); only the cross-platform `build` job runs (via `always()`), uploading the frozen apps as **run artifacts** `RNAlysis-BETA-<target>-<sha>` (14-day retention) instead of Release assets.
- **Inert on real tag pushes** — `github.event_name == 'push'`, so `createrelease` and the release-asset upload run exactly as before. It's the *same* `build` job a release uses, so a green beta faithfully predicts the release freeze.

**`.claude/skills/release/SKILL.md`**
- Documents the two lanes and a self-contained **Beta lane** section: dispatch command, download/quarantine notes (incl. GitHub's double-zip), the explicit ❌ isolation contract, and a guardrail-verification snippet.
- States the **"`HISTORY.rst` date is stamped only at stable promotion"** rule as the guardrail binding both lanes.

## Isolation contract (the whole point)

A beta does **not**: bump the version, stamp the `HISTORY.rst` date, commit to `master`/`development`, create a tag, regen the vocabulary/docs artifacts, upload to PyPI, or create any GitHub Release. Nothing to clean up.

## Code review

An independent clean-context review ran on the diff. It caught a real footgun in the first draft — a `beta=false` manual dispatch would have run `createrelease` — which is fixed by dropping the input and discriminating on `github.event_name` (also resolving the default-branch input-schema concern and a boolean-coercion fragility). Two doc nits fixed: the `gh run watch` lookup now filters by branch + event and waits for the run to register (was racing `--limit 1`), and the download steps document GitHub's double-zip.

## Testing

No unit-testable surface (CI-workflow YAML + a documentation skill). The workflow YAML was validated to parse with all job/step gates confirmed. The one real test is a **live dispatch, which only the maintainer can run**:

```bash
gh workflow run pyinstaller.yml --ref development
# then confirm both RNAlysis-BETA-* zips appear as run artifacts and `git log origin/master -1` is unchanged
```

## Dropped from the original proposal (see #283)

The published-PEP-440-pre-release path (bump to `4.3.0b1`, PyPI `--pre` upload, GitHub pre-release) was intentionally cut — the goal is freeze verification + manual testing, not distribution, and a committed `bN` bump is exactly the shared-state residue the isolation contract forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
