### PR TITLE
Add a pre-commit CI check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,40 @@
+name: Pre-commit
+
+# Runs the hooks defined in .pre-commit-config.yaml (Ruff format + import sort, end-of-file
+# fixer, trailing whitespace, LF line-ending enforcement, YAML/TOML checks, merge-conflict
+# markers, large-file check -- see that file for the authoritative, up-to-date hook list) against
+# only the files a PR actually touches -- NOT the whole repository. The tree has not had its
+# one-time reformat sweep yet (see the comments atop .pre-commit-config.yaml / ruff.toml), so a
+# `--all-files` gate would fail on every PR until that sweep lands. `--from-ref`/`--to-ref` scopes
+# the run to the PR's diff, matching what `pre-commit install` already does locally on
+# `git commit` (hooks run only on the files that commit touches).
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    pre-commit:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Get repository
+                uses: actions/checkout@v7
+                with:
+                    # Full history is needed so both the PR's base and head commits are present
+                    # locally for the --from-ref/--to-ref diff below.
+                    fetch-depth: 0
+                    # docs/build/ is ~600 MB of committed, generated Sphinx output that no hook
+                    # needs to see; excluding it from the sparse checkout speeds this up.
+                    sparse-checkout: |
+                        /*
+                        !/docs/build
+                    sparse-checkout-cone-mode: false
+            -   name: Set up Python
+                uses: actions/setup-python@v7
+                with:
+                    python-version: '3.13'
+            -   name: Run pre-commit on the PR's changed files
+                uses: pre-commit/action@v3.0.1
+                with:
+                    extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,13 @@
 #     pre-commit install
 #
 # After that the hooks run automatically on `git commit`, but ONLY on the files that commit
-# touches. Adding this file does not reformat the repository, and there is no CI gate yet — a
-# single repo-wide `ruff format` / `ruff check --fix` sweep is planned separately, when
-# `development` is next merged into `master`. To run everything by hand: `pre-commit run -a`.
+# touches. Adding this file does not reformat the repository — a single repo-wide `ruff format` /
+# `ruff check --fix` sweep is planned separately, when `development` is next merged into
+# `master`. To run everything by hand: `pre-commit run -a`.
+#
+# CI (.github/workflows/pre-commit.yml) runs these same hooks on every pull request, scoped to
+# just the files the PR changed (`pre-commit run --from-ref <base> --to-ref <head>`) — NOT
+# `--all-files`, since the repo-wide sweep above hasn't happened yet.
 
 default_language_version:
   python: python3

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -141,6 +141,10 @@ Before you submit a pull request, check that it meets these guidelines:
    on Windows, macOS, and Linux. GitHub Actions runs this matrix automatically on every pull
    request; make sure all jobs pass. Coverage is reported at
    https://coveralls.io/github/GuyTeichman/RNAlysis.
+5. The files your pull request touches must pass the pre-commit hooks (Ruff formatting/import
+   sorting, end-of-file/whitespace fixups, YAML/TOML validity). GitHub Actions checks this
+   automatically, scoped to just the files the PR changed. Installing the git hook with
+   ``pre-commit install`` (see "Get Started!" above) catches this before you push.
 
 Tips
 ----


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pre-commit.yml`, which runs the hooks already defined in `.pre-commit-config.yaml` (Ruff check/fix + format, EOF fixer, trailing whitespace, LF enforcement, YAML/TOML checks, merge-conflict/large-file checks) on every pull request.
- Scoped to each PR's changed files only (`pre-commit run --from-ref <base> --to-ref <head>`), not `--all-files` — the repo-wide `ruff format`/`ruff check --fix` sweep is still pending, so a full-tree gate would fail on every PR until that lands.
- Updates the stale "no CI gate yet" comment in `.pre-commit-config.yaml` and adds a short mention of the new check to `CONTRIBUTING.rst`'s PR guidelines.
- `pre-commit`/`ruff` were already added to `requirements_dev.txt` in a prior commit, so that part of the issue was already done.

Closes #290.

## Test plan
- [x] Validated the new workflow YAML parses (`yaml.safe_load`).
- [x] Verified `pre-commit/action`'s default command (`pre-commit run --show-diff-on-failure --color=always <extra_args>`) so `--from-ref`/`--to-ref` correctly replaces `--all-files`.
- [x] Independent code review (clean-context) run against the diff; two documentation-accuracy nits found and fixed (an ambiguous "see step 3 above" cross-reference in CONTRIBUTING.rst, and an incomplete hook list in the new workflow's header comment).
- [ ] Confirm the new "Pre-commit" check actually runs and passes on this PR in GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)