### PR TITLE
Scope MANIFEST.in root includes to top-level files (stop sweeping in .claude/build/dist)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
-recursive-include . *.rst *.ico *.png
-recursive-include . requirements*.txt
+# Top-level metadata files only (non-recursive). `recursive-include .` walks the ENTIRE working
+# tree and sweeps in whatever happens to be sitting in it (build/, dist/, .claude/ worktrees, ...),
+# bloating source builds. Package/tests/docs content is included by the explicit rules below.
+include *.rst *.ico *.png
+include requirements*.txt
 
 recursive-include rnalysis *.png *.svg *.json *.qss *.R *.ico *.css *.js *.html *.md
 recursive-include rnalysis/data_files/ *


### PR DESCRIPTION
## What
`MANIFEST.in`'s first two lines used `recursive-include .`, which walks the **entire** working
tree from the repo root. A source build (`python setup.py sdist`) from a non-pristine checkout
therefore swept in anything sitting in the directory — `build/`, `dist/`, and (the trigger for
this) **`.claude/` agent worktrees**.

```diff
-recursive-include . *.rst *.ico *.png
-recursive-include . requirements*.txt
+# Top-level metadata files only (non-recursive)...
+include *.rst *.ico *.png
+include requirements*.txt
```

## Why
While cutting 4.3.0, a working-dir `make release` produced a **417 MB** sdist — 361 MB of it was
`.claude/worktrees/` matched by `recursive-include . *.png/*.rst/*.ico`. That exceeds PyPI's
100 MB per-file limit. A clean checkout builds a valid **~67 MB** sdist, but relying on the
checkout being pristine is fragile; `include` (root-only) makes source builds robust regardless
of what's in the working tree.

## Verification (this is a serialized-artifact change, so proven empirically, not unit-tested)
Built the sdist from a clean `git archive master` export **before and after** the change:
- before: 1320 files · after: 1320 files · **file-set diff: empty** (nothing added or dropped).

So a clean/CI build ships byte-identical source content; only the working-tree pollution stops
being picked up. `rnalysis/`, `tests/`, and `docs/` content continues to come from their own
explicit `recursive-include` rules below.

## Scope
Build hygiene only — no runtime/behavior/results change, so no `HISTORY.rst` entry (and this is
**not** part of the in-flight 4.3.0 release; 4.3.0's PyPI artifact is built from a clean clone).
