### PR TITLE
docs: fix invalid "install from sources" commands in installation.rst

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -137,13 +137,13 @@ Once you have a copy of the source, you can install the basic version of *RNAlys
 
 .. code-block:: console
 
-    $ python -m pip setup.py install
+    $ pip install .
 
 Or you can install the full version of *RNAlysis* with:
 
 .. code-block:: console
 
-    $ python -m pip setup.py install .[all]
+    $ pip install .[all]
 
 
 .. _Github repository: https://github.com/GuyTeichman/RNAlysis


### PR DESCRIPTION
Fixes #99

## Summary
The "From sources" section of `docs/source/installation.rst` showed two invalid install commands:

- `$ python -m pip setup.py install`
- `$ python -m pip setup.py install .[all]`

`pip` has no `setup.py` subcommand, and `.[all]` was misplaced in the second line, so neither command runs.

They are replaced with the modern equivalents, preserving the surrounding reST `.. code-block:: console` formatting and `$` prompt style:

- `$ pip install .`
- `$ pip install .[all]`

Docs-only change; no code, tests, or GUI dialogs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)