### PR TITLE
Docs: correct Linux tutorial-video deps to Qt6 image-format plugins

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -73,9 +73,9 @@ you should first install `GraphViz <https://graphviz.org/download/>`_, `R`_, and
 
 **On Windows:** you may also need to install `Microsoft Visual C++ 14.0 <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ or greater, and `Perl <https://strawberryperl.com/>`_.
 
-**On Linux:** you may also need to install **Qt 5 Image Formats** to view tutorial videos from within *RNAlysis*.
-To do so on Debian/ubuntu systems, use the command `sudo apt install qt5-image-formats-plugins`.
-To do so on Red Hat-based distros such as Fedora, use the command `dnf install qt5-qtimageformats`.
+**On Linux:** you may also need to install **Qt 6 Image Formats** to view tutorial videos from within *RNAlysis*.
+To do so on Debian/ubuntu systems, use the command `sudo apt install qt6-image-formats-plugins`.
+To do so on Red Hat-based distros such as Fedora, use the command `dnf install qt6-qtimageformats`.
 
 After installing these external dependencies, you can install *RNAlysis* by typing the following command in your terminal window::
 


### PR DESCRIPTION
Fixes #101

## Summary

`docs/source/installation.rst` told Linux users to install the **Qt5** image-format plugins so in-app tutorial videos would play. RNAlysis switched to **Qt6** in v4.1.0, so those were the wrong packages. This updates the Linux instructions to their Qt6 equivalents and fixes the surrounding "Qt 5" prose to "Qt 6".

## Changes (before → after)

| Distro | Before | After |
| --- | --- | --- |
| Debian/Ubuntu | `qt5-image-formats-plugins` | `qt6-image-formats-plugins` |
| Fedora / Red Hat | `qt5-qtimageformats` | `qt6-qtimageformats` |
| Prose | "**Qt 5** Image Formats" | "**Qt 6** Image Formats" |

## Fedora package confirmation

The issue explicitly asked to confirm the current Fedora package name before merging. I verified `qt6-qtimageformats` against the official Fedora package repository: it is the active "Qt6 - QtImageFormats component" package, currently maintained across Rawhide, 45, 44, 43 (and earlier releases), providing the optional Qt6 image-format plugins (MNG, TGA, TIFF, WBMP). It installs with `dnf install qt6-qtimageformats`.

Source: https://packages.fedoraproject.org/pkgs/qt6-qtimageformats/qt6-qtimageformats/

## Notes

- Docs-only change; no code, no GUI dialog affected (rule 9 screenshot requirement N/A).
- Pure docs fix, so no `HISTORY.rst` entry.
- The existing `HISTORY.rst` note "RNAlysis now runs on Qt6 instead of Qt5" is a correct historical changelog entry and was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
