### PR TITLE
Reparent widgets before deleteLater in remaining teardown sites (#135)

### DIFF
--- a/rnalysis/gui/gui.py
+++ b/rnalysis/gui/gui.py
@@ -1206,8 +1206,9 @@ class SetOperationWindow(gui_widgets.MinMaxDialog):
     def update_paremeter_ui(self):
         # delete previous widgets
         try:
-            self.parameter_widgets['help_link'].deleteLater()
             self.operations_grid.removeWidget(self.parameter_widgets['help_link'])
+            self.parameter_widgets['help_link'].setParent(None)
+            self.parameter_widgets['help_link'].deleteLater()
         except KeyError:
             pass
         self.parameter_widgets = {}
@@ -1464,8 +1465,9 @@ class SetVisualizationWindow(gui_widgets.MinMaxDialog):
     def update_parameter_ui(self):
         # delete previous widgets
         try:
-            self.parameter_widgets['help_link'].deleteLater()
             self.visualization_grid.removeWidget(self.parameter_widgets['help_link'])
+            self.parameter_widgets['help_link'].setParent(None)
+            self.parameter_widgets['help_link'].deleteLater()
         except KeyError:
             pass
         self.parameter_widgets = {}

--- a/rnalysis/gui/gui_widgets.py
+++ b/rnalysis/gui/gui_widgets.py
@@ -2420,8 +2420,10 @@ def get_val_from_widget(widget):
 def clear_layout(layout, exceptions: set = frozenset()):
     while layout.count() > len(exceptions):
         child = layout.takeAt(0)
-        if child.widget() and child.widget() not in exceptions:
-            child.widget().deleteLater()
+        widget = child.widget()
+        if widget and widget not in exceptions:
+            widget.setParent(None)
+            widget.deleteLater()
 
 
 def mark_primary(button: QtWidgets.QAbstractButton):


### PR DESCRIPTION
Fixes #135

## Summary

Follow-up from the code review of #132, which hardened the two `create_canvas` methods against a flaky native teardown crash by adopting the order `removeWidget()` → `setParent(None)` → `deleteLater()`. This applies the same order to the remaining widget-teardown sites for consistency/defensive hygiene (these operate on static input widgets, so they are not believed to reproduce the #132 crash — this is a consistency change, not a bug fix).

Changes:

- **`rnalysis/gui/gui.py`** — `SetOperationWindow.update_paremeter_ui` and `SetVisualizationWindow.update_parameter_ui` tore down the `help_link` label as `deleteLater()` *before* `removeWidget()`, and never reparented it. Reordered both to `removeWidget()` → `setParent(None)` → `deleteLater()`, matching the reference pattern already used for the `canvas`/`toolbar` widgets.
- **`rnalysis/gui/gui_widgets.py`** — `clear_layout()` now reparents each widget to `None` before scheduling deletion. The widget handle is captured into a local before `setParent(None)`, because a `QLayoutItem`'s `widget()` returns `None` once the widget has been reparented away (verified via `test_clear_layout` — calling `child.widget()` again after `setParent(None)` raises `AttributeError`).

No user-visible change: this only reorders internal widget teardown. No public API signature, parameter, `@readable_name`, `:param:` help text, or type annotation changed, so rule 9 (GUI screenshots) does not apply.

## Tests

Run locally on Windows with `QT_QPA_PLATFORM=offscreen`:

- `tests/test_gui_widgets.py -k clear_layout` — **passed** (directly exercises the changed helper).
- `tests/test_gui.py -k "SetOperationWindow or SetVisualizationWindow"` — **73 passed, 1 failed**. The single failure, `test_SetVisualizationWindow_canvas_types[UpSet Plot]` (an UpSet preview-canvas render assertion), **fails identically on the clean `origin/development` base**, so it is a pre-existing headless-render flake unrelated to this change.

Not run: full suite / R / kallisto / bowtie2 / network paths (out of scope for this GUI-teardown change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
