### PR TITLE
Break majority-vote taxon-inference ties deterministically (#247)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1 (unreleased)
+------------------
+
+Fixed
+******
+* Fixed non-deterministic taxon inference: when inferring an organism from a set of gene IDs (``infer_taxon_from_gene_ids``, used by enrichment analysis in automatic-organism mode) and the gene IDs match more than one species by an *equal* number of genes, the winning species is now chosen deterministically — the highest gene count, and among ties the first scientific name in alphabetical order. Previously the tie was broken by the iteration order of a Python ``set``, which varies per process under hash randomization (``PYTHONHASHSEED``), so the same gene-ID set could infer a different taxon from one run to the next and fork the entire downstream analysis. Cases where a single species is an outright majority are unaffected, and their results are unchanged.
+
 4.3.0 (2026-08-26)
 -------------------
 

--- a/rnalysis/utils/io.py
+++ b/rnalysis/utils/io.py
@@ -1364,16 +1364,15 @@ def infer_taxon_from_gene_ids(gene_ids: Iterable[str], gene_id_type: str = None)
             species[output[gene_id]['species']] = species.setdefault(output[gene_id]['species'], 0) + 1
     if len(species) == 0:
         raise ValueError('No taxon ID could be matched to any of the given gene IDs.')
-    chosen_species = list(species.keys())[0]
-    chosen_species_n = species[chosen_species]
     if len(species) > 1:
         warnings.warn(
-            'The given gene IDs match more than one species. Picking the species that fits the majority of gene IDs.'
+            'The given gene IDs match more than one species. Picking the species that fits the majority of gene IDs '
+            '(ties are broken deterministically by choosing the first species name in alphabetical order).'
         )
-        for s in species:
-            if species[s] > chosen_species_n:
-                chosen_species = s
-                chosen_species_n = species[s]
+    # Break majority-vote ties deterministically: pick the highest count, then the alphabetically-first
+    # species name. `species` keys derive from a set of gene IDs, so their iteration order varies per
+    # process under hash randomization (PYTHONHASHSEED); sorting first makes the winner reproducible.
+    chosen_species = max(sorted(species.keys()), key=lambda s: species[s])
     return map_taxon_id(chosen_species.replace('_', ' ')), map_from
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -929,6 +929,34 @@ def test_infer_taxon_from_gene_ids_no_species(monkeypatch):
         infer_taxon_from_gene_ids([])
 
 
+def test_infer_taxon_from_gene_ids_breaks_ties_deterministically(monkeypatch):
+    # A genuine majority-vote tie: two species with equal gene counts. The winner must be chosen
+    # deterministically (alphabetically-first scientific name), regardless of the order in which the
+    # species happen to be encountered - that order traces back to a set of gene IDs and therefore
+    # varies per process under hash randomization (PYTHONHASHSEED).
+    monkeypatch.setattr(io, 'map_taxon_id', lambda x: x)
+    monkeypatch.setattr(
+        io, 'find_best_gene_mapping', lambda *args, **kwargs: (Mock(mapping_dict={}), 'WormBase', 'Ensembl')
+    )
+    # 'apis_mellifera' sorts before 'zea_mays', so it must win the tie no matter the encounter order.
+    tie_zea_first = {
+        'id1': {'species': 'zea_mays'},
+        'id2': {'species': 'zea_mays'},
+        'id3': {'species': 'apis_mellifera'},
+        'id4': {'species': 'apis_mellifera'},
+    }
+    tie_apis_first = {
+        'id1': {'species': 'apis_mellifera'},
+        'id2': {'species': 'apis_mellifera'},
+        'id3': {'species': 'zea_mays'},
+        'id4': {'species': 'zea_mays'},
+    }
+    for gene_id_info in (tie_zea_first, tie_apis_first):
+        monkeypatch.setattr(io, '_ensembl_lookup_post_request', lambda x: gene_id_info)
+        with pytest.warns(Warning):
+            assert infer_taxon_from_gene_ids([])[0] == 'apis mellifera'
+
+
 ids_uniprot = ['P34544', 'Q27395', 'P12844']
 ids_wormbase = ['WBGene00019883', 'WBGene00023497', 'WBGene00003515']
 entrez_to_wb_truth = {'176183': 'WBGene00019883', '173203': 'WBGene00012343'}


### PR DESCRIPTION
Fixes #247

## Summary
`infer_taxon_from_gene_ids` (`rnalysis/utils/io.py`) infers an organism from a set of gene IDs by a species majority vote. It broke ties by **first-seen order**, iterating a dict whose insertion order traces back to a Python `set` of gene IDs. Under hash randomization (`PYTHONHASHSEED`) that order varies per process, so on a genuine tie — two species with equal gene counts, realistic for small or mixed-species lists — the inferred taxon could differ **run-to-run**, forking everything downstream (which annotations get fetched, the whole enrichment).

The tie is now broken deterministically:
```python
chosen_species = max(sorted(species.keys()), key=lambda s: species[s])
```
i.e. **highest gene count, then the alphabetically-first scientific name**. `max` returns the first element among equal keys, and iterating a pre-sorted list makes that the alphabetically-first name — fully reproducible regardless of set/hash iteration order.

### Tie-break key chosen
Alphabetically-first **scientific name** (the Ensembl species string already held as the `species` dict key). The dict keys are species *names*, not taxon IDs; the name is the natural stable secondary key and is available in-hand, so this avoids the extra per-species `map_taxon_id` network round-trips that sorting by NCBI taxon ID would require. The non-tie (clear-majority) and single-species paths are unchanged.

The multi-species `warnings.warn` now also states that ties are resolved deterministically by scientific name.

## Tests
- Added `test_infer_taxon_from_gene_ids_breaks_ties_deterministically` — constructs a two-species tie (equal counts) and feeds it in **both** encounter orders, asserting the same winner (`apis mellifera`, which sorts before `zea_mays`) each time. Fails on the old first-seen code (returns `zea mays` for one ordering), passes on the fix. Fully mocked (`map_taxon_id`, `_ensembl_lookup_post_request`, `find_best_gene_mapping`) — no network.
- Ran `python -m pytest tests/test_io.py -k "taxon or infer"` → **28 passed** (offline).
- An independent clean-context review of the diff was performed and approved.
- Not run: the full `test_io.py` suite (parts hit UniProt/Ensembl/network and R/Qt paths are unrelated to this change).

## HISTORY.rst
Added a new `4.3.1 (unreleased)` section with a `Fixed` entry noting the tie-break is now stable (previously depended on Python hash-seed / set iteration order and could differ run-to-run). Clear-majority cases are unaffected and their results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
