### PR TITLE
Fix obs float-truncation corrupting randomization-test p-values (#274)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1 (unreleased)
+-------------------
+
+Fixed
+******
+* Fixed a bug that could corrupt the results of the set-based enrichment tests (hypergeometric, Fisher's exact, and randomization) on certain gene-set sizes. The observed overlap count (the ``obs`` column these tests report) was re-derived from a fraction and could come out one short of the true value on specific (gene-set size, overlap) pairs — for example, a gene set of 49 genes overlapping an annotation in exactly 1 gene was reported as ``0`` — because a floating-point round-trip (``int(en_size * (en_attr_size / en_size))``) truncated the count. The count is now taken directly as the exact size of the overlap. More seriously, this also **corrected the randomization enrichment test's p-value on affected inputs**: because that test used the truncated ``obs`` as its success threshold, an affected term could report a p-value of roughly 1.0 regardless of its true enrichment — a silent false negative that the user could not predict. **Results may change:** the randomization test's p-values (and the ``obs`` column reported by these set-based tests) for affected gene-set sizes now reflect the corrected count; unaffected sizes are unchanged.
+
 4.3.0 (2026-08-26)
 -------------------
 

--- a/rnalysis/utils/enrichment_runner.py
+++ b/rnalysis/utils/enrichment_runner.py
@@ -116,7 +116,9 @@ class StatsTest(abc.ABC):
         expected_fraction = attr_size / bg_size
         observed_fraction = en_attr_size / en_size
         log2_fold_enrichment = np.log2(observed_fraction / expected_fraction) if observed_fraction > 0 else -np.inf
-        obs, exp = int(en_size * observed_fraction), en_size * expected_fraction
+        # obs is the observed overlap count; it equals en_attr_size exactly by definition. Re-deriving it as
+        # int(en_size * observed_fraction) truncated below en_attr_size on float-imprecise pairs (issue #274).
+        obs, exp = en_attr_size, en_size * expected_fraction
 
         return bg_size, en_size, attr_size, en_attr_size, obs, exp, log2_fold_enrichment
 

--- a/tests/test_enrichment_runner.py
+++ b/tests/test_enrichment_runner.py
@@ -623,6 +623,34 @@ def test_get_hypergeometric_parameters(attr, truth):
     assert res == truth
 
 
+def _make_hypergeometric_sets(en_size: int, en_attr_size: int):
+    # gene_set of `en_size` genes; annotation_set is a subset of `en_attr_size` of them, so the
+    # observed overlap (gene_set & annotation_set) is exactly `en_attr_size` by construction.
+    gene_set = {f'gene{i}' for i in range(en_size)}
+    annotation_set = {f'gene{i}' for i in range(en_attr_size)}
+    background_set = set(gene_set)
+    return annotation_set, gene_set, background_set
+
+
+@pytest.mark.parametrize('en_size,en_attr_size', [(49, 1), (98, 1), (98, 2), (103, 1), (103, 2), (22, 15), (47, 3)])
+def test_get_hypergeometric_params_obs_no_float_truncation(en_size, en_attr_size):
+    # regression for issue #274: obs was re-derived as int(en_size * (en_attr_size / en_size)),
+    # which truncates below en_attr_size on float-imprecise pairs (e.g. 49*(1/49) == 0.999...).
+    annotation_set, gene_set, background_set = _make_hypergeometric_sets(en_size, en_attr_size)
+    obs = HypergeometricTest().get_hypergeometric_params(annotation_set, gene_set, background_set)[4]
+    assert obs == en_attr_size
+
+
+def test_get_hypergeometric_params_obs_equals_intersection_size_sweep():
+    # obs must equal the true intersection size for every (set-size, overlap) pair.
+    pval_func = HypergeometricTest()
+    for en_size in range(1, 201):
+        for en_attr_size in range(0, en_size + 1):
+            annotation_set, gene_set, background_set = _make_hypergeometric_sets(en_size, en_attr_size)
+            obs = pval_func.get_hypergeometric_params(annotation_set, gene_set, background_set)[4]
+            assert obs == en_attr_size, (en_size, en_attr_size, obs)
+
+
 @pytest.mark.parametrize(
     'params,truth',
     [


### PR DESCRIPTION
Fixes #274

## Summary
`StatsTest.get_hypergeometric_params` (`rnalysis/utils/enrichment_runner.py`) re-derived the observed overlap count through a float round-trip:

```python
observed_fraction = en_attr_size / en_size
obs = int(en_size * observed_fraction)   # == en_attr_size, EXCEPT when float truncation bites
```

On float-imprecise `(en_size, en_attr_size)` pairs this truncates `obs` one below the true value (e.g. `en_size=49, en_attr_size=1` -> `obs=0`, because `49*(1/49)` is `0.999...` and `int()` floors). Consequences:

1. The reported `obs` column of the **set-based** enrichment tests (hypergeometric, Fisher's exact, randomization) was wrong on affected sizes.
2. **The randomization test's p-value was silently corrupted:** `PermutationTest.run` passes `obs / en_size` as the success threshold. With `obs` truncated to 0 on an enriched attribute, every permutation clears the threshold -> `p ~= 1.0` regardless of true enrichment — a silent false negative on inputs the user cannot predict.

`obs` is exactly the intersection size by definition, so it is now taken directly as `en_attr_size` (one token). This also makes the randomization threshold consistent with `log2_fold_enrichment`, which was already computed from the un-truncated `observed_fraction`.

## Tests
Added to `tests/test_enrichment_runner.py`:
- `test_get_hypergeometric_params_obs_no_float_truncation` — pinned regression on `(49, 1)` plus other truncation-prone pairs `(98,1)`, `(98,2)`, `(103,1)`, `(103,2)`, `(22,15)`, `(47,3)`; each fails before the fix.
- `test_get_hypergeometric_params_obs_equals_intersection_size_sweep` — sweeps every `(set-size, overlap)` pair for `en_size` 1..200 (755 truncating pairs), asserting `obs == en_attr_size`.

Ran (pure numeric — no R/network/Qt):
- `python -m pytest tests/test_enrichment_runner.py -k "hypergeometric or obs or randomization or permutation"` -> 19 passed
- `python -m pytest tests/test_enrichment_runner.py` -> 241 passed
- `python -m pytest tests/test_enrichment.py -k "enrichment_randomization_validity or enrichment_parallel_validity or enrich_hypergeometric_pvalues"` -> 3 passed

Existing reference CSVs are unaffected: their `obs` values (at `samples=10`) are not truncation-prone, so they already match the corrected output. An independent clean-context review confirmed the fix and traced every consumer of `get_hypergeometric_params`.

## HISTORY / rule 5
Added a `4.3.1 (unreleased)` `Fixed` entry with a bolded **"Results may change"** callout: the randomization test's p-values (and the `obs` column of the set-based tests) change on affected gene-set sizes; unaffected sizes are unchanged. Per the recorded maintainer decision, ship in a minor release.

## Not included (deferred)
The related `TTest.run` NaN-policy asymmetry noted in the issue (`np.nanmean` for background vs plain `np.mean` for the gene set) is **not** addressed here: it changes numerical output for NaN-containing gene sets, needs a decision on `ttest_1samp`'s `nan_policy` and whether to mirror the change in `SignTest`, and would expand this PR's scope/risk beyond the required `obs` fix. Left for a separate PR.

## GUI screenshots
Not applicable — no public signature or annotation change, so no dialog is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
