### PR TITLE
Fix common_suffix for 3+ strings and the tautological lcs_only filter (#195)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1 (unreleased)
+-------------------
+
+Fixed
+******
+* Fixed a bug in the automatic sample-name generation used when RNAlysis derives a shared name for paired-end FASTQ files (the "smart" paired-end naming path). With three or more samples, two flaws in the underlying common-substring/common-suffix logic could yield a wrong sample name: the shared trailing part was computed from only two of the file names (so a differing third name was ignored), and a fallback entry for a sample with no distinctive shared substring was wrongly allowed to influence that computation. Both are now corrected, so the shared suffix is trimmed consistently from every sample. As a result, the automatically generated common/sample names may differ (for the better) in some three-or-more-sample edge cases — for example three paired-end samples ``ctrl1``, ``ctrl2`` and ``treat1`` now yield the names ``ctrl1``/``ctrl2``/``treat1`` instead of the previous inconsistent ``ctrl``/``ctrl2_R``/``treat``. Two-sample cases, and any case whose name was already correct, are unaffected. You can always rename samples manually regardless.
+
 4.3.0 (2026-08-26)
 -------------------
 

--- a/rnalysis/utils/parsing.py
+++ b/rnalysis/utils/parsing.py
@@ -475,13 +475,16 @@ def common_suffix(strings):
     """Find the common suffix among a list of strings."""
     if not strings:
         return ''
-    s1 = min(strings)
-    s2 = max(strings)
-    max_overlap = min(len(s1), len(s2))
+    # The suffix must be shared by *every* string, so compare all of them character-by-character from
+    # the end. (Comparing only min/max -- valid for a common prefix -- is wrong for a suffix, because
+    # lexicographic order says nothing about how strings end; see issue #195.)
+    shortest = min(strings, key=len)
+    max_overlap = len(shortest)
     for i in range(max_overlap):
-        if s1[-(i + 1)] != s2[-(i + 1)]:
-            return s1[len(s1) - i :]
-    return s1[len(s1) - max_overlap :]
+        char = shortest[-(i + 1)]
+        if any(s[-(i + 1)] != char for s in strings):
+            return shortest[len(shortest) - i :]
+    return shortest[len(shortest) - max_overlap :]
 
 
 def remove_suffix(s: str, suffix: Union[str, List[str]]):
@@ -505,16 +508,18 @@ def generate_common_name(file_pairs):
 
     # Prepare output based on comparison
     initial_results = []
-    pair_lengths = []
+    is_genuine_lcs = []
     for s1, s2, lcs in lcs_list:
-        pair_lengths.append(len(s1) + len(s2))
         if len(lcs) > len(overall_lcs):
             initial_results.append(lcs)
+            is_genuine_lcs.append(True)
         else:
             initial_results.append(s1 + s2)
-    # Find and trim common suffix from LCSs (compare each result against its OWN pair's combined
-    # length, not the loop variables left over from the last iteration of the loop above)
-    lcs_only = [result for result, pair_length in zip(initial_results, pair_lengths) if len(result) <= pair_length]
+            is_genuine_lcs.append(False)
+    # Find and trim the common suffix, computed over the genuine LCS results only. The `s1 + s2`
+    # concatenated fallbacks are excluded: their trailing characters are not part of a real shared
+    # sample name and would otherwise mask (or spuriously alter) the suffix shared by the true LCSs.
+    lcs_only = [result for result, genuine in zip(initial_results, is_genuine_lcs) if genuine]
     suffix = common_suffix(lcs_only)
     if suffix and len(lcs_only) > 1:
         trimmed_results = [

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -375,6 +375,10 @@ def test_longest_common_substring(s1, s2, expected):
         (['日本語abc', '中国語abc'], '語abc'),  # unicode suffix
         (['ab', 'aab'], 'ab'),  # lexicographically-smaller string is longer than the larger one (issue #180)
         (['aac', 'ab'], ''),  # same as above, but with no shared suffix at all
+        # issue #195: a string that is neither the lexicographic min nor max must still be able to break
+        # the suffix. 'ax' and 'zx' (min/max) both end in 'x', but 'cy' does not -> no common suffix.
+        (['zx', 'ax', 'cy'], ''),
+        (['abc', 'xbc', 'ybc'], 'bc'),  # issue #195: a genuine shared suffix across 3+ strings
     ],
 )
 def test_common_suffix(strings, expected):
@@ -407,8 +411,10 @@ def test_remove_suffix(s, suffix, expected):
         ([('sample1_R1', 'sample1_R2'), ('sample2_R1', 'sample2_R2')], ['sample1', 'sample2']),  # two pairs
         (
             [('ctrl1_R1', 'ctrl1_R2'), ('ctrl2_R1', 'ctrl2_R2'), ('treat1_R1', 'treat1_R2')],
-            ['ctrl', 'ctrl2_R', 'treat'],
-        ),  # three pairs, uneven trimming across pairs
+            ['ctrl1', 'ctrl2', 'treat1'],
+        ),  # issue #195: the genuinely shared "_R" suffix is now trimmed evenly from every pair. Before
+        # the common_suffix fix this ignored the non-min/max 'ctrl2_R' and mis-trimmed "1_R", yielding
+        # the inconsistent ['ctrl', 'ctrl2_R', 'treat'].
         ([('abc', 'xyz')], ['abcxyz']),  # no common substring: names are concatenated
         ([('same', 'same')], ['same']),  # all-identical inputs
         ([('sample1_R1_trimmed', 'sample1_R2_trimmed')], ['sample1_R']),  # known suffixes are stripped first
@@ -422,6 +428,15 @@ def test_remove_suffix(s, suffix, expected):
         # pair here is much shorter, the earlier (longer) pair's valid LCS result was wrongly
         # excluded from the common-suffix computation, so the shared trailing "_R" was never trimmed.
         ([('sampleA_long_name_R1', 'sampleA_long_name_R2'), ('sB_R1', 'sB_R2')], ['sampleA_long_name', 'sB']),
+        # regression test for issue #195: the third pair shares nothing beyond the global "common" LCS, so
+        # it falls back to concatenation ('commonPPcommonQQ'). The old tautological `lcs_only` filter kept
+        # that fallback in the common-suffix computation, so its trailing 'QQ' masked the real "_S" suffix
+        # shared by the genuine LCS results and it was never trimmed. Now the suffix is computed over the
+        # genuine LCS results only, so "_S" is correctly stripped from the first two names.
+        (
+            [('commonAB_S1', 'commonAB_S2'), ('commonCD_S1', 'commonCD_S2'), ('commonPP', 'commonQQ')],
+            ['commonAB', 'commonCD', 'commonPPcommonQQ'],
+        ),
     ],
 )
 def test_generate_common_name(file_pairs, expected):


### PR DESCRIPTION
Fixes #195

## Summary

Fixes two pre-existing correctness bugs in automatic common/sample-name generation (`rnalysis/utils/parsing.py`). Both feed the "smart" paired-end FASTQ sample-naming path (`fastq.py`) and could silently produce a wrong sample name with 3 or more samples. Neither is a crash.

**Bug 1 — `common_suffix` was wrong for 3+ strings.** It compared only the lexicographic `min` and `max` of the input. That is valid for a common *prefix* but not a *suffix*: any string that is neither the min nor the max was ignored, so it could report a suffix that some inputs don't actually share (e.g. `common_suffix(['zx','ax','cy'])` returned `'x'` instead of `''`, because `'cy'` ends in `'y'`). It now compares every string character-by-character from the end.

**Bug 2 — the `lcs_only` filter in `generate_common_name` was a tautology.** `[result for result, pair_length in zip(...) if len(result) <= pair_length]` is always true (a fallback `s1 + s2` has length exactly `pair_length`, and any real LCS is `<= len(s1)+len(s2)`), so it never excluded anything and the common-suffix trimming was computed over the `s1 + s2` concatenated fallbacks too. It now tracks which entries took the genuine-LCS branch (`is_genuine_lcs`) and feeds `common_suffix` only those, so a fallback entry can no longer mask or alter the suffix shared by the real sample names.

## Tests added (TDD: written failing first, then fixed)

`tests/test_parsing.py`:
- `common_suffix`: `['zx','ax','cy'] -> ''` (a non-min/max string breaks the suffix) and `['abc','xbc','ybc'] -> 'bc'` (a genuine 3-string shared suffix).
- `generate_common_name`: `[('commonAB_S1','commonAB_S2'),('commonCD_S1','commonCD_S2'),('commonPP','commonQQ')] -> ['commonAB','commonCD','commonPPcommonQQ']` — the third pair falls back to concatenation, and only with the `lcs_only` fix is the real `_S` suffix trimmed from the genuine names.
- Updated one existing `generate_common_name` case that had encoded the buggy uneven trimming: `[('ctrl1_R1','ctrl1_R2'),('ctrl2_R1','ctrl2_R2'),('treat1_R1','treat1_R2')]` now yields `['ctrl1','ctrl2','treat1']` (shared `_R` trimmed evenly) instead of the previous inconsistent `['ctrl','ctrl2_R','treat']`.

### Before / after test results
- Before the fix: 3 failures — `test_common_suffix[strings10-]` (the `['zx','ax','cy']` case), `test_generate_common_name[file_pairs3-expected3]` (updated ctrl/treat case), and `test_generate_common_name[file_pairs10-expected10]` (new `lcs_only` corruption case).
- After the fix: `python -m pytest tests/test_parsing.py -k "common_suffix or common_name"` -> 23 passed; full `tests/test_parsing.py` -> 186 passed.

These are pure functions — no R / network / Qt / kallisto needed, so the tests were run locally and pass.

## HISTORY note (rule 5)

Added a `4.3.1 (unreleased)` → `Fixed` entry in `HISTORY.rst` calling out that automatic common/sample-name generation could produce a wrong name in some 3-or-more-sample edge cases and is now corrected, with a concrete before/after example. Two-sample cases and any already-correct case are unchanged.

## Notes

- No public API signature change; `common_suffix(strings)` and `generate_common_name(file_pairs)` keep their signatures. No GUI dialog surface (internal parsing helpers, no `@readable_name`/`:param:`/annotations), so rule 9 screenshots are not applicable.
- Independently reviewed with clean context (rule 8): LGTM, no issues; the reviewer re-derived the expected values by hand and confirmed the `num_pairs>1 -> num_genuine_lcs>1` guard change is correct and necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)