### PR TITLE
Warn on mispaired R1/R2 file lists in paired-end wrappers (#279)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1 (unreleased)
+-------------------
+
+Added
+******
+* The paired-end FASTQ functions (adapter trimming, bowtie2 and kallisto alignment/quantification, and FASTQ-to-SAM conversion) now emit a warning when the R1 and R2 file lists appear to be mispaired by list order — that is, when a pair's filenames carry mismatched sample names after stripping the standard read-number tokens (``_R1_``/``_R2_``, ``_R1.``/``_R2.``, ``_1.``/``_2.``). Because mates are paired strictly by list position, two file lists selected in different orders would otherwise silently cross-pair samples and produce a garbage count matrix that nothing downstream can detect. The warning names the suspect pair(s); it is advisory only and never blocks the run, so datasets that legitimately use non-conventional filenames are unaffected.
+
 4.3.0 (2026-08-26)
 -------------------
 

--- a/rnalysis/fastq.py
+++ b/rnalysis/fastq.py
@@ -7,6 +7,7 @@ the *bowtie2* alignment tool, and the *featureCounts* feature counting tool.
 import abc
 import itertools
 import os
+import re
 import shutil
 import sys
 import types
@@ -53,6 +54,56 @@ def _func_type(func_type: Literal['single', 'paired', 'both']):
         return item
 
     return decorator
+
+
+# Read-number token used by the standard paired-end FASTQ naming conventions: '_R1_'/'_R2_'
+# (Illumina, e.g. 'sample_R1_001.fastq.gz'), '_R1.'/'_R2.' before the extension, and '_1.'/'_2.'.
+# The read number (1 or 2) is captured, and the token must be followed by '.', '_', or the end of
+# the name so that a digit inside the sample name (e.g. 'control_2reps') is not mistaken for it.
+# The optional 'R' is matched case-insensitively ('_r1_' is recognized too).
+_PAIRED_READ_TOKEN = re.compile(r'_R?([12])(?=[._]|$)', re.IGNORECASE)
+
+
+def _paired_mate_sample_key(filename: Union[str, Path]) -> Union[str, None]:
+    """
+    Reduce a paired-end FASTQ filename to the sample-name portion that precedes its read-number
+    token (e.g. 'sampleA_R1_001.fastq.gz' -> 'sampleA'), so two files can be checked for being
+    mates regardless of file extension or the text following the read token. The *last* read-number
+    token in the name is used, so a replicate number earlier in the name (e.g. 'control_1_R1') does
+    not shadow the real read token. Returns ``None`` when no recognized read-number token is found
+    (unconventional naming), in which case the pairing cannot be sanity-checked.
+    """
+    name = Path(filename).name
+    matches = list(_PAIRED_READ_TOKEN.finditer(name))
+    if not matches:
+        return None
+    return name[: matches[-1].start()]
+
+
+def _check_paired_mate_names(r1_files, r2_files):
+    """
+    Warn (without raising) when R1/R2 files paired by list order do not appear to be mates.
+
+    Paired-end wrappers match mates strictly by list position (``zip(r1_files, r2_files)``); if the
+    two file lists were selected in different orders — trivial to do in a GUI multi-file picker —
+    samples are silently cross-paired and nothing downstream can detect the resulting garbage. This
+    compares the sample-name prefix of each R1 file with its R2 partner (after stripping the
+    standard read-number tokens '_R1_'/'_R2_', '_R1.'/'_R2.', '_1.'/'_2.') and emits a loud warning
+    naming any suspect pair. Files with unconventional names (no recognizable read token) are
+    skipped rather than flagged, so intentionally non-conventional datasets still run. This is a
+    sanity check only: it never changes behavior and never raises.
+    """
+    for i, (r1, r2) in enumerate(zip(r1_files, r2_files)):
+        key1 = _paired_mate_sample_key(r1)
+        key2 = _paired_mate_sample_key(r2)
+        if key1 is None or key2 is None:
+            continue
+        if key1 != key2:
+            warnings.warn(
+                f"r1_files[{i}] '{Path(r1).name}' is paired with '{Path(r2).name}' — these "
+                f'filenames do not appear to be mates; pairs are matched by list order. Verify '
+                f'that r1_files and r2_files are listed in the same sample order.'
+            )
 
 
 class _FASTQPipeline(generic.GenericPipeline, abc.ABC):
@@ -585,6 +636,8 @@ def fastq_to_sam_paired(
         raise InvalidValueError('output_folder does not exist!')
 
     base_call, script_name = _parse_fastq2sam_misc_args(picard_installation_folder, quality_score_type)
+
+    _check_paired_mate_names(r1_files, r2_files)
 
     calls = []
 
@@ -1808,6 +1861,8 @@ def bowtie2_align_paired_end(
             f'Number of samples ({len(r1_files)}) does not match number of sample names ({len(new_sample_names)})!'
         )
 
+    _check_paired_mate_names(r1_files, r2_files)
+
     if not isinstance(min_fragment_length, int):
         raise InvalidTypeError("'min_fragment_len' must be a non-negative int!")
     if not (min_fragment_length >= 0):
@@ -2198,6 +2253,8 @@ def kallisto_quantify_paired_end(
         raise InvalidValueError(
             f'Number of samples ({len(r1_files)}) does not match number of sample names ({len(new_sample_names)})!'
         )
+
+    _check_paired_mate_names(r1_files, r2_files)
 
     # handle legacy arguments
     learn_bias = legacy_args.get('learn_bias', False)
@@ -2635,6 +2692,8 @@ def trim_adapters_paired_end(
         raise InvalidValueError(
             f'Number of samples ({len(r1_files)}) does not match number of sample names ({len(new_sample_names)})!'
         )
+
+    _check_paired_mate_names(r1_files, r2_files)
 
     try:
         call = io.generate_base_call('cutadapt', 'auto')

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,5 +1,6 @@
 import gzip
 import platform
+import warnings
 from unittest.mock import Mock
 
 import polars as pl
@@ -127,6 +128,96 @@ def test_validation_survives_python_optimize():
     )
     result = subprocess.run([sys.executable, '-O', '-c', code], capture_output=True, text=True)
     assert 'RAISED' in result.stdout, result.stderr
+
+
+# --- paired-end mate-name sanity check ----------------------------------------------------------
+# Paired-end wrappers pair mates strictly by list position (zip(r1_files, r2_files)); if the two
+# file lists were selected in different orders, samples are silently cross-paired. The pure-string
+# helper _check_paired_mate_names warns (never raises) when a pair's filenames don't look like
+# mates, using the standard read-number tokens '_R1_'/'_R2_', '_R1.'/'_R2.', and '_1.'/'_2.'.
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'r1_files,r2_files',
+    [
+        # conventional Illumina _R1_/_R2_ pairs, correct order
+        (
+            ['sampleA_R1_001.fastq.gz', 'sampleB_R1_001.fastq.gz'],
+            ['sampleA_R2_001.fastq.gz', 'sampleB_R2_001.fastq.gz'],
+        ),
+        # _R1./_R2. right before the extension
+        (['sampleA_R1.fastq.gz'], ['sampleA_R2.fastq.gz']),
+        # _1./_2. convention, mixed extensions
+        (['sampleA_1.fastq.gz', 'ctrl_1.fastq'], ['sampleA_2.fastq.gz', 'ctrl_2.fastq']),
+        # a replicate number in the sample name must not be mistaken for the read token
+        (
+            ['control_1_R1.fastq.gz', 'control_2_R1.fastq.gz'],
+            ['control_1_R2.fastq.gz', 'control_2_R2.fastq.gz'],
+        ),
+        # unconventional naming with no recognizable read token -> skipped, no warning
+        (['weird_left.fq', 'other_left.fq'], ['weird_right.fq', 'other_right.fq']),
+        # nothing to check
+        ([], []),
+        # Path objects, not just strings
+        ([Path('reads/sampleA_R1.fastq.gz')], [Path('reads/sampleA_R2.fastq.gz')]),
+    ],
+)
+def test_check_paired_mate_names_accepts_well_formed_pairs(r1_files, r2_files):
+    # simplefilter('error') makes any emitted warning raise, so a clean run proves no warning
+    # (and that unconventional-but-intentional naming still runs rather than raising).
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert fastq._check_paired_mate_names(r1_files, r2_files) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'r1_files,r2_files,bad_index,bad_r1,bad_r2',
+    [
+        # R2 list selected in a different order -> both pairs cross-paired; index 0 is reported
+        (
+            ['sampleA_R1.fastq.gz', 'sampleB_R1.fastq.gz'],
+            ['sampleB_R2.fastq.gz', 'sampleA_R2.fastq.gz'],
+            0,
+            'sampleA_R1.fastq.gz',
+            'sampleB_R2.fastq.gz',
+        ),
+        # single mispaired pair, _1./_2. convention
+        (['ctrl_1.fastq.gz'], ['treat_2.fastq.gz'], 0, 'ctrl_1.fastq.gz', 'treat_2.fastq.gz'),
+        # Illumina _R1_/_R2_ mispaired
+        (['s1_R1_001.fastq.gz'], ['s2_R2_001.fastq.gz'], 0, 's1_R1_001.fastq.gz', 's2_R2_001.fastq.gz'),
+        # correct first pair, mispaired second pair -> the offending index is 1, not 0
+        (
+            ['sampleA_R1.fastq.gz', 'sampleB_R1.fastq.gz'],
+            ['sampleA_R2.fastq.gz', 'sampleC_R2.fastq.gz'],
+            1,
+            'sampleB_R1.fastq.gz',
+            'sampleC_R2.fastq.gz',
+        ),
+    ],
+)
+def test_check_paired_mate_names_warns_on_mispaired(r1_files, r2_files, bad_index, bad_r1, bad_r2):
+    with pytest.warns(UserWarning) as record:
+        fastq._check_paired_mate_names(r1_files, r2_files)
+    messages = ' '.join(str(w.message) for w in record)
+    assert f'r1_files[{bad_index}]' in messages
+    assert bad_r1 in messages
+    assert bad_r2 in messages
+    assert 'do not appear to be mates' in messages
+
+
+@pytest.mark.unit
+def test_bowtie2_align_paired_end_warns_on_mispaired_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(io, 'generate_base_call', lambda *args, **kwargs: ['bowtie2'])
+    monkeypatch.setattr(io, 'run_subprocess', lambda *args, **kwargs: (0, []))
+    with pytest.warns(UserWarning, match='do not appear to be mates'):
+        bowtie2_align_paired_end(
+            ['sampleA_R1.fastq.gz', 'sampleB_R1.fastq.gz'],
+            ['sampleB_R2.fastq.gz', 'sampleA_R2.fastq.gz'],
+            tmp_path,
+            'index',
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #279

## Summary
All paired-end FASTQ wrappers pair mates strictly by list position (`zip(r1_files, r2_files)`). If the R1 and R2 file lists are selected in different orders — trivial in a GUI multi-file picker — samples are silently cross-paired, and the aligners "succeed" on mismatched mates, producing a garbage count matrix that nothing downstream can detect.

This adds a **warning-only** sanity check (per the maintainer decision recorded in the issue — some datasets legitimately violate naming conventions, so we protect the non-expert user without blocking power users).

## What changed
- New private helper `_check_paired_mate_names(r1_files, r2_files)` in `rnalysis/fastq.py`. For each pair it strips the recognized read-number token from each filename and compares the remaining sample-name prefixes; on a mismatch it emits a loud `warnings.warn(...)` naming the suspect pair and its list index, e.g.:
  > r1_files[0] 'sampleA_R1.fastq.gz' is paired with 'sampleB_R2.fastq.gz' — these filenames do not appear to be mates; pairs are matched by list order. Verify that r1_files and r2_files are listed in the same sample order.
- Wired into all four paired-end wrappers that do `zip(r1_files, r2_files)`: `fastq_to_sam_paired`, `bowtie2_align_paired_end`, `kallisto_quantify_paired_end`, and `trim_adapters_paired_end`. (The pipeline path `PairedEndPipeline.apply_to` dispatches through these wrappers, so it is covered too.)
- The helper is `warnings.warn` — the mechanism already used elsewhere in `fastq.py` and surfaced by the GUI. No new GUI mechanism was invented.

### Token conventions recognized
Regex `_R?([12])(?=[._]|$)` (case-insensitive on the `R`), operating on the file's basename, matches the standard paired-end conventions: `_R1_`/`_R2_` (Illumina, e.g. `sample_R1_001.fastq.gz`), `_R1.`/`_R2.` before the extension, and `_1.`/`_2.`. The **last** matching token is used, so a biological replicate number earlier in the name (e.g. `control_1_R1`) does not shadow the real read token. The lookahead prevents digits inside a sample name (e.g. `control_2reps_R1`) from being mistaken for the read token. Files with no recognizable token yield no key and are skipped (no warning) — unconventional-but-intentional naming still runs.

### Behavior guarantees
- Advisory only: the helper **never raises** and never changes analysis behavior.
- No new public parameter, annotation, `@readable_name`, or `:param:` help text was added or changed on any public function — so there is **no GUI dialog change**, and rule 9 (screenshots) does not apply. Only underscore-prefixed module-level names were added (excluded from GUI reflection).
- Back-compat preserved (no serialized-format or signature change); results reproduce (warning-only).

## Tests
Added to `tests/test_fastq.py` (all `@pytest.mark.unit`, pure string logic — no external tools needed for the helper; the one wrapper-integration test mocks `io.run_subprocess`/`io.generate_base_call`):
- `test_check_paired_mate_names_accepts_well_formed_pairs` — parametrized over `_R1_`/`_R2_`, `_R1.`/`_R2.`, `_1.`/`_2.`, replicate-number-in-name, unconventional (no-token), empty, and `Path`-object inputs; asserts **no** warning via `warnings.simplefilter('error')`.
- `test_check_paired_mate_names_warns_on_mispaired` — parametrized over cross-ordered lists and single mispairs across conventions; asserts the warning names the correct index and both filenames.
- `test_bowtie2_align_paired_end_warns_on_mispaired_files` — integration test through the public wrapper with mocked subprocess, asserting the warning surfaces.

Results:
- `pytest tests/test_fastq.py -k "check_paired_mate_names or warns_on_mispaired_files"` → **12 passed**
- `pytest tests/test_fastq.py -m unit` → **31 passed**
- Mock-based command tests (`-k "command or validates or rejects ..."`) → **70 passed**, no regressions (existing paired tests use `reads_1`/`reads_2`, same prefix → no spurious warning).
- Not run: full integration paths that require kallisto/bowtie2/cutadapt/R binaries and a network/Qt display (unchanged by this PR).

An independent clean-context review of the diff found no correctness bugs.

## HISTORY
Added a `4.3.1 (unreleased)` → `Added` entry describing the new advisory warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)