### PR TITLE
Fix report node-name suffix doubling on session reload

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+4.3.1
+-----
+
+Fixed
+*****
+* Fixed a bug where reloading a saved session duplicated the ``(#id)`` suffix on every data node's label in the analysis report: a table loaded as ``... (#3)`` became ``... (#3) (#3)`` when the session was reloaded, and grew by another ``(#3)`` on each further save-and-reload. Node labels in reports built from reloaded sessions are now stable.
+
 4.3.0 (2026-08-26)
 -------------------
 

--- a/rnalysis/gui/gui_report.py
+++ b/rnalysis/gui/gui_report.py
@@ -29,7 +29,14 @@ class Node:
     }
 
     def __init__(
-        self, node_id: int, node_name: str, predecessors: list, popup_element: str, node_type: str, filename: str = None
+        self,
+        node_id: int,
+        node_name: str,
+        predecessors: list,
+        popup_element: str,
+        node_type: str,
+        filename: str = None,
+        _add_id_suffix: bool = True,
     ):
         self._node_id = node_id
         self._node_name = node_name
@@ -38,7 +45,10 @@ class Node:
         self._node_type = node_type
         self._is_active = True
         self._filename = None if filename is None else Path(filename)
-        if node_type in self.DATA_TYPES:
+        # data-type nodes are labeled with their id (e.g. "... (#3)"). When a node is rebuilt from a
+        # serialized session (from_json), node_name already carries this suffix, so it must not be
+        # re-appended - otherwise every save/reload round-trip would duplicate it.
+        if _add_id_suffix and node_type in self.DATA_TYPES:
             self._node_name += f' (#{node_id})'
 
     def to_json(self):
@@ -65,6 +75,7 @@ class Node:
             popup_element=data['popup_element'],
             node_type=data['node_type'],
             filename=Path(data['filename']) if data['filename'] else None,
+            _add_id_suffix=False,
         )
 
     @property

--- a/tests/test_gui_report.py
+++ b/tests/test_gui_report.py
@@ -105,3 +105,22 @@ def test_generate_report(report_generator, tmp_path):
     report_file = tmp_path / 'report.html'
     assert report_file.exists()
     assert len(report_generator.graph.nodes) == 9
+
+
+def test_serialize_deserialize_preserves_data_node_names(report_generator):
+    # data-type nodes carry an auto '(#id)' suffix; saving and reloading a session must NOT
+    # duplicate it. Regression test for the suffix doubling on every serialize/deserialize round-trip.
+    report_generator.add_node('Loaded Count matrix', 1, [0], 'popup', 'Count matrix', 'a.parquet')
+    report_generator.add_node('Normalize', 2, [1], 'normalize_to_rpm(inplace=False)', 'Function', None)
+    report_generator.add_node('Count matrix (normalized)', 3, [2], 'popup', 'Count matrix', 'b.parquet')
+    original_names = {nid: node.node_name for nid, node in report_generator.nodes.items()}
+    assert original_names[1] == 'Loaded Count matrix (#1)'
+
+    data, _ = report_generator.serialize()
+    restored = ReportGenerator.deserialize(data)
+    assert {nid: node.node_name for nid, node in restored.nodes.items()} == original_names
+
+    # idempotent across repeated round-trips (a session saved and reloaded several times)
+    data2, _ = restored.serialize()
+    restored2 = ReportGenerator.deserialize(data2)
+    assert {nid: node.node_name for nid, node in restored2.nodes.items()} == original_names


### PR DESCRIPTION
## What

Reloading a saved session duplicated the `(#id)` suffix on every **data-type** node's label in the analysis report. A table loaded as `... (#3)` became `... (#3) (#3)` after one save-and-reload, and grew by another `(#3)` on each further round-trip.

## Cause

`Node.to_json()` stores the already-suffixed name, and `Node.from_json()` fed it back through `Node.__init__`, which re-appends the `(#id)` suffix for data-type nodes. Every serialize→deserialize therefore duplicated it.

## Fix

Gate the suffixing behind an `_add_id_suffix` flag that `from_json` sets to `False`, so a node rebuilt from a session keeps its stored label verbatim. Function nodes were never affected (they carry no suffix).

**Back-compat:** sessions saved by older versions store a single suffix and now reload without the extra one — i.e. they render *more* correctly than before. No serialized-format change.

## Tests

- New regression test asserts data-node names are stable across repeated serialize/deserialize round-trips.
- `tests/test_gui_report.py` (14) and the `tests/test_io.py` session suite (17) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)